### PR TITLE
Add support for logging request & response headers (in logstash-access)

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,5 +400,16 @@ The default field names used for access logs are different than those documented
 See [`LogstashAccessFieldNames`](/src/main/java/net/logstash/logback/fieldnames/LogstashAccessFieldNames.java)
 for all the field names used for access logs.
 
+By default, the request and response headers are not logged. If you want to include them, you need to configure the encoder like that :
+
+```xml
+<encoder class="net.logstash.logback.encoder.LogstashAccessEncoder">
+  <fieldNames>
+    <fieldsRequestHeaders>@fields.request_headers</fieldsRequestHeaders>
+    <fieldsResponseHeaders>@fields.response_headers</fieldsResponseHeaders>
+  </fieldNames>
+</encoder>
+```
+
 ## Build status
 [![Build Status](https://travis-ci.org/logstash/logstash-logback-encoder.svg?branch=master)](https://travis-ci.org/logstash/logstash-logback-encoder)

--- a/src/main/java/net/logstash/logback/LogstashAccessFormatter.java
+++ b/src/main/java/net/logstash/logback/LogstashAccessFormatter.java
@@ -60,6 +60,8 @@ public class LogstashAccessFormatter extends LogstashAbstractFormatter<IAccessEv
         writeStringField(generator, fieldNames.getFieldsRemoteUser(), event.getRemoteUser());
         writeNumberField(generator, fieldNames.getFieldsContentLength(), event.getContentLength());
         writeNumberField(generator, fieldNames.getFieldsElapsedTime(), event.getElapsedTime());
+        writeMapStringFields(generator, fieldNames.getFieldsRequestHeaders(), event.getRequestHeaderMap());
+        writeMapStringFields(generator, fieldNames.getFieldsResponseHeaders(), event.getResponseHeaderMap());
         
         writeContextPropertiesIfNecessary(generator, context);
     }

--- a/src/main/java/net/logstash/logback/fieldnames/LogstashAccessFieldNames.java
+++ b/src/main/java/net/logstash/logback/fieldnames/LogstashAccessFieldNames.java
@@ -24,6 +24,8 @@ public class LogstashAccessFieldNames extends LogstashCommonFieldNames {
     private String fieldsRemoteUser = "@fields.remote_user";
     private String fieldsContentLength = "@fields.content_length";
     private String fieldsElapsedTime = "@fields.elapsed_time";
+    private String fieldsRequestHeaders = "@fields.request_headers";
+    private String fieldsResponseHeaders = "@fields.response_headers";
     
     public LogstashAccessFieldNames() {
         /*
@@ -32,6 +34,14 @@ public class LogstashAccessFieldNames extends LogstashCommonFieldNames {
          * LogstashEncoder uses 'message'.
          */
         setMessage("@message");
+
+        /*
+         * By default:
+         * fieldsRequestHeaders and fieldsResponseHeaders are ignored
+         * because those fields can be quite big.
+         */
+        setFieldsRequestHeaders(IGNORE_FIELD_INDICATOR);
+        setFieldsResponseHeaders(IGNORE_FIELD_INDICATOR);
     }
 
     public String getFieldsMethod() {
@@ -112,5 +122,21 @@ public class LogstashAccessFieldNames extends LogstashCommonFieldNames {
 
     public void setFieldsElapsedTime(String fieldsElapsedTime) {
         this.fieldsElapsedTime = fieldsElapsedTime;
+    }
+
+    public String getFieldsRequestHeaders() {
+      return fieldsRequestHeaders;
+    }
+
+    public void setFieldsRequestHeaders(String fieldsRequestHeaders) {
+      this.fieldsRequestHeaders = fieldsRequestHeaders;
+    }
+
+    public String getFieldsResponseHeaders() {
+      return fieldsResponseHeaders;
+    }
+
+    public void setFieldsResponseHeaders(String fieldsResponseHeaders) {
+      this.fieldsResponseHeaders = fieldsResponseHeaders;
     }
 }

--- a/src/main/java/net/logstash/logback/fieldnames/LogstashCommonFieldNames.java
+++ b/src/main/java/net/logstash/logback/fieldnames/LogstashCommonFieldNames.java
@@ -18,6 +18,20 @@ package net.logstash.logback.fieldnames;
  * and the {@link net.logstash.logback.LogstashAccessFormatter}. 
  */
 public abstract class LogstashCommonFieldNames {
+    /**
+     * Field name to use in logback configuration files
+     * if you want the field to be ignored (not output).
+     * 
+     * Unfortunately, logback does not provide a way to set a
+     * field value to null via xml config,
+     * so we have to fall back to using this magic string.
+     * 
+     * Note that if you're programmatically configuring the field names,
+     * then you can just set the field name to null in the
+     * FieldNamesType.  
+     */
+    public static final String IGNORE_FIELD_INDICATOR = "[ignore]";
+  
     private String timestamp = "@timestamp";
     private String version = "@version";
     private String message = "message";

--- a/src/test/java/net/logstash/logback/encoder/LogstashEncoderTest.java
+++ b/src/test/java/net/logstash/logback/encoder/LogstashEncoderTest.java
@@ -34,9 +34,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import net.logstash.logback.LogstashFormatter;
 import net.logstash.logback.decorate.JsonFactoryDecorator;
 import net.logstash.logback.decorate.JsonGeneratorDecorator;
+import net.logstash.logback.fieldnames.LogstashCommonFieldNames;
 import net.logstash.logback.fieldnames.ShortenedFieldNames;
 
 import org.apache.commons.io.IOUtils;
@@ -632,7 +632,7 @@ public class LogstashEncoderTest {
          * make sure it doesn't appear.
          */
         assertThat(node.get("@version"), is(nullValue()));
-        assertThat(node.get(LogstashFormatter.IGNORE_FIELD_INDICATOR), is(nullValue()));
+        assertThat(node.get(LogstashCommonFieldNames.IGNORE_FIELD_INDICATOR), is(nullValue()));
         
         assertThat(node.get("appname").textValue(), is("damnGodWebservice"));
         assertThat(node.get("appendedName").textValue(), is("appendedValue"));


### PR DESCRIPTION
Disabled by default (because it can be quite big), but it can be activated with:

    <encoder class="net.logstash.logback.encoder.LogstashAccessEncoder">
      <fieldNames>
        <fieldsRequestHeaders>@fields.request_headers</fieldsRequestHeaders>
        <fieldsResponseHeaders>@fields.response_headers</fieldsResponseHeaders>
      </fieldNames>
    </encoder>