### PR TITLE
Added mdc fields white list filtering

### DIFF
--- a/src/main/java/net/logstash/logback/LogstashFormatter.java
+++ b/src/main/java/net/logstash/logback/LogstashFormatter.java
@@ -13,30 +13,25 @@
  */
 package net.logstash.logback;
 
-import java.io.IOException;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Map.Entry;
-
-import net.logstash.logback.fieldnames.LogstashFieldNames;
-import net.logstash.logback.marker.LogstashMarker;
-import net.logstash.logback.marker.Markers;
-
-import org.slf4j.MDC;
-import org.slf4j.Marker;
-
 import ch.qos.logback.classic.pattern.Abbreviator;
 import ch.qos.logback.classic.pattern.ExtendedThrowableProxyConverter;
 import ch.qos.logback.classic.pattern.TargetLengthBasedClassNameAbbreviator;
 import ch.qos.logback.classic.pattern.ThrowableHandlingConverter;
-import ch.qos.logback.classic.pattern.ThrowableProxyConverter;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.IThrowableProxy;
 import ch.qos.logback.core.Context;
 import ch.qos.logback.core.spi.ContextAware;
-
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
+import net.logstash.logback.fieldnames.LogstashFieldNames;
+import net.logstash.logback.marker.LogstashMarker;
+import net.logstash.logback.marker.Markers;
+import org.slf4j.MDC;
+import org.slf4j.Marker;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.Map.Entry;
 
 /**
  * 
@@ -99,7 +94,7 @@ public class LogstashFormatter extends LogstashAbstractFormatter<ILoggingEvent, 
      * When true, {@link MDC} properties will be included.
      */
     private boolean includeMdc = true;
-    
+
     /**
      * Used to format throwables as Strings.
      */
@@ -235,6 +230,12 @@ public class LogstashFormatter extends LogstashAbstractFormatter<ILoggingEvent, 
             if (mdcProperties != null && !mdcProperties.isEmpty()) {
                 if (fieldNames.getMdc() != null) {
                     generator.writeObjectFieldStart(fieldNames.getMdc());
+                }
+                List<String> mdcFieldNames = fieldNames.getMdcFieldNamesList();
+                if (!mdcFieldNames.isEmpty()) {
+                    Map<String, String> includedProperties = new HashMap<String, String>(mdcProperties);
+                    includedProperties.keySet().retainAll(mdcFieldNames);
+                    mdcProperties = includedProperties;
                 }
                 writeMapEntries(generator, mdcProperties);
                 if (fieldNames.getMdc() != null) {
@@ -384,15 +385,15 @@ public class LogstashFormatter extends LogstashAbstractFormatter<ILoggingEvent, 
     public void setIncludeMdc(boolean includeMdc) {
         this.includeMdc = includeMdc;
     }
-    
+
     public boolean isIncludeContext() {
         return includeContext;
     }
-    
+
     public void setIncludeContext(boolean includeContext) {
         this.includeContext = includeContext;
     }
-    
+
     public ThrowableHandlingConverter getThrowableConverter() {
         return throwableConverter;
     }
@@ -400,7 +401,7 @@ public class LogstashFormatter extends LogstashAbstractFormatter<ILoggingEvent, 
     public void setThrowableConverter(ThrowableHandlingConverter throwableConverter) {
         this.throwableConverter = throwableConverter;
     }
-    
+
     /**
      * @deprecated When logging, prefer using a {@link Markers#appendEntries(Map)} marker instead.
      */
@@ -408,7 +409,7 @@ public class LogstashFormatter extends LogstashAbstractFormatter<ILoggingEvent, 
     public boolean isEnableContextMap() {
         return enableContextMap;
     }
-    
+
     /**
      * @deprecated When logging, prefer using a {@link Markers#appendEntries(Map)} marker instead.
      */

--- a/src/main/java/net/logstash/logback/encoder/LogstashEncoder.java
+++ b/src/main/java/net/logstash/logback/encoder/LogstashEncoder.java
@@ -111,7 +111,7 @@ public class LogstashEncoder extends EncoderBase<ILoggingEvent> {
     public void setIncludeMdc(boolean includeMdc) {
         formatter.setIncludeMdc(includeMdc);
     }
-    
+
     public boolean isIncludeContext() {
         return formatter.isIncludeContext();
     }

--- a/src/main/java/net/logstash/logback/fieldnames/LogstashCommonFieldNames.java
+++ b/src/main/java/net/logstash/logback/fieldnames/LogstashCommonFieldNames.java
@@ -13,6 +13,10 @@
  */
 package net.logstash.logback.fieldnames;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 /**
  * Common field names between the regular {@link net.logstash.logback.LogstashFormatter}
  * and the {@link net.logstash.logback.LogstashAccessFormatter}. 
@@ -21,6 +25,8 @@ public abstract class LogstashCommonFieldNames {
     private String timestamp = "@timestamp";
     private String version = "@version";
     private String message = "message";
+    private String mdcFieldNames = null;
+    private List<String> mdcFieldNamesList = Collections.emptyList();
 
     public String getTimestamp() {
         return timestamp;
@@ -44,5 +50,20 @@ public abstract class LogstashCommonFieldNames {
 
     public void setMessage(String message) {
         this.message = message;
+    }
+
+    public String getMdcFieldNames() {
+        return this.mdcFieldNames;
+    }
+
+    public void setMdcFieldNames(String commaSeparatedFieldNames) {
+        this.mdcFieldNames = commaSeparatedFieldNames;
+        if (this.mdcFieldNames != null) {
+            this.mdcFieldNamesList = Collections.unmodifiableList(Arrays.asList(mdcFieldNames.split(",")));
+        }
+    }
+
+    public List<String> getMdcFieldNamesList() {
+        return this.mdcFieldNamesList;
     }
 }

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -13,6 +13,7 @@
             <customFields>{"appname":"damnGodWebservice","roles":["customerorder", "auth"], "buildinfo": { "version" : "Version 0.1.0-SNAPSHOT", "lastcommit" : "75473700d5befa953c45f630c6d9105413c16fe1"} }</customFields>
             <fieldNames class="net.logstash.logback.fieldnames.ShortenedFieldNames">
                 <version>[ignore]</version>
+                <mdcFieldNames>myMdcField</mdcFieldNames>
             </fieldNames>
             <includeMdc>false</includeMdc>
         </encoder>


### PR DESCRIPTION
Hi,

I created this pull request since I need to be able to control which MDC properties are logged and which are not. The reason is that I live in a framework which uses MDC heavily and I want to create a very specific and lightweight log, so I need to filter out most of the framework's MDC information.

Your feedback is appreciated.

Thanks,
Shai