### PR TITLE
Fix KeepAliveCharset configuration property (gh121)

### DIFF
--- a/src/main/java/net/logstash/logback/appender/AbstractLogstashTcpSocketAppender.java
+++ b/src/main/java/net/logstash/logback/appender/AbstractLogstashTcpSocketAppender.java
@@ -736,8 +736,8 @@ public abstract class AbstractLogstashTcpSocketAppender<Event extends DeferredPr
      * The charset to use when writing the {@link #keepAliveMessage}.
      * Defaults to UTF-8.
      */
-   public void setKeepAliveCharset(String keepAliveCharset) {
-        this.keepAliveCharset = Charset.forName(keepAliveCharset);
+   public void setKeepAliveCharset(Charset keepAliveCharset) {
+        this.keepAliveCharset = keepAliveCharset;
     }
     
 }


### PR DESCRIPTION
Let logback/joran handles the string/Charset conversion and make sure getter/setter are of the same type so the property is correctly recognised by Joran during configuration.
See https://github.com/logstash/logstash-logback-encoder/issues/121 for more information.