### PR TITLE
Don't log stacktrace on unknown host exception

### DIFF
--- a/src/main/java/net/logstash/logback/appender/AbstractLogstashTcpSocketAppender.java
+++ b/src/main/java/net/logstash/logback/appender/AbstractLogstashTcpSocketAppender.java
@@ -909,7 +909,7 @@ public abstract class AbstractLogstashTcpSocketAppender<Event extends DeferredPr
                  * Warn, but don't fail startup, so that transient
                  * DNS problems are allowed to resolve themselves eventually.
                  */
-                addWarn("Invalid destination '" + getHostString(destination) + "': host unknown (was '" + getHostString(destination) + "').", ex);
+                addWarn("Invalid destination '" + getHostString(destination) + "': host unknown (was '" + getHostString(destination) + "').");
             }
             this.destinations.add(destination);
         }


### PR DESCRIPTION
IMHO the stack trace is of limited value here. We're using destinations that will never resolve in DNS that's only used in local development (e.g. references to docker container names). 

Other warnings emitted on initializing logback typically don't include stack traces, e.g:

`13:16:49,461 |-WARN in ch.qos.logback.classic.LoggerContext[default] - Resource [logback.xml] occurs multiple times on the classpath.`