### PR TITLE
Update jackson dependency due to CVE-2016-3720

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <ch.qos.logback.version>1.1.6</ch.qos.logback.version>
-        <com.fasterxml.jackson.version>2.6.5</com.fasterxml.jackson.version>
+        <com.fasterxml.jackson.version>2.8.6</com.fasterxml.jackson.version>
         <commons.io.version>2.4</commons.io.version>
         <commons.lang.version>2.6</commons.lang.version>
         <junit.version>4.12</junit.version>


### PR DESCRIPTION
XML external entity (XXE) vulnerability in XmlMapper in the Data format
extension for Jackson (aka jackson-dataformat-xml) allows attackers to
have unspecified impact via unknown vectors.

fasterxml:jackson:2.7.3 and previous versions are affected.

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-3720