### PR TITLE
Make code logback-1.2-compatible and fix tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <ch.qos.logback.version>1.1.6</ch.qos.logback.version>
+        <ch.qos.logback.version>1.2.1</ch.qos.logback.version>
         <com.fasterxml.jackson.version>2.6.5</com.fasterxml.jackson.version>
         <commons.io.version>2.4</commons.io.version>
         <commons.lang.version>2.6</commons.lang.version>

--- a/src/main/java/net/logstash/logback/appender/AbstractLogstashTcpSocketAppender.java
+++ b/src/main/java/net/logstash/logback/appender/AbstractLogstashTcpSocketAppender.java
@@ -438,7 +438,7 @@ public abstract class AbstractLogstashTcpSocketAppender<Event extends DeferredPr
                          * This is a standard (non-keepAlive) event.
                          * Therefore, we need to send the event.
                          */
-                        encoder.doEncode(logEvent.event);
+                        outputStream.write(encoder.encode(logEvent.event));
                     } else if (hasKeepAliveDurationElapsed(lastSentTimestamp, currentTime)){
                         /*
                          * This is a keep alive event, and the keepAliveDuration has passed,
@@ -536,8 +536,6 @@ public abstract class AbstractLogstashTcpSocketAppender<Event extends DeferredPr
                     tempSocket.connect(new InetSocketAddress(getHostString(currentDestination), currentDestination.getPort()), acceptConnectionTimeout);
                     tempOutputStream = new BufferedOutputStream(tempSocket.getOutputStream(), writeBufferSize);
                     
-                    encoder.init(tempOutputStream);
-                    
                     addInfo(peerId + "connection established.");
                     
                     this.socket = tempSocket;
@@ -634,13 +632,6 @@ public abstract class AbstractLogstashTcpSocketAppender<Event extends DeferredPr
         }
         
         private void closeEncoder() {
-            try {
-                encoder.close();
-            } catch (IOException ioe) {
-                addStatus(new ErrorStatus(
-                        "Failed to close encoder", this, ioe));
-            }
-            
             encoder.stop();
         }
         

--- a/src/main/java/net/logstash/logback/encoder/CompositeJsonEncoder.java
+++ b/src/main/java/net/logstash/logback/encoder/CompositeJsonEncoder.java
@@ -14,9 +14,9 @@
 package net.logstash.logback.encoder;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.nio.charset.Charset;
 
+import org.apache.commons.lang.ArrayUtils;
 import net.logstash.logback.composite.CompositeJsonFormatter;
 import net.logstash.logback.composite.JsonProviders;
 import net.logstash.logback.decorate.JsonFactoryDecorator;
@@ -27,75 +27,83 @@ import ch.qos.logback.core.encoder.LayoutWrappingEncoder;
 import ch.qos.logback.core.pattern.PatternLayoutBase;
 import ch.qos.logback.core.spi.DeferredProcessingAware;
 
+
 public abstract class CompositeJsonEncoder<Event extends DeferredProcessingAware>
         extends EncoderBase<Event> {
-    
+
+    private static final byte[] EMPTY_BYTES = new byte[]{};
+
+    /**
+     * TODO: Should this flag be removed?
+     * We have no control over flushing output stream now (logback-1.2)
+     * because we only could return byte[] buffer from encode() method.
+     *
+     * Could be marked as @Deprecated may be?
+     */
     private boolean immediateFlush = true;
-    
+
     private Encoder<Event> prefix;
     private Encoder<Event> suffix;
-    
+
     private final CompositeJsonFormatter<Event> formatter;
-    
+
     private String lineSeparator = System.getProperty("line.separator");
-    
+
     private byte[] lineSeparatorBytes;
-    
+
     private Charset charset;
-    
+
     public CompositeJsonEncoder() {
         super();
         this.formatter = createFormatter();
     }
-    
+
     protected abstract CompositeJsonFormatter<Event> createFormatter();
-    
-    @Override
-    public void init(OutputStream os) throws IOException {
-        
-        initWrapped(prefix, os);
-        super.init(os);
-        initWrapped(suffix, os);
-        
-    }
 
-    private void initWrapped(Encoder<Event> wrapped, OutputStream os) throws IOException {
-        if (wrapped != null) {
-            wrapped.init(os);
-        }
+    @Override
+    public byte[] headerBytes() {
+        return EMPTY_BYTES;
     }
 
     @Override
-    public void doEncode(Event event) throws IOException {
-        
+    public byte[] encode(Event event) {
         try {
-            doEncodeWrapped(prefix, event);
-            
-            formatter.writeEventToOutputStream(event, outputStream);
-    
-            doEncodeWrapped(suffix, event);
-            
-            if (lineSeparatorBytes != null) {
-                outputStream.write(lineSeparatorBytes);
+            final byte[] prefixBytes = doEncodeWrapped(prefix, event);
+            final byte[] bytes = getEventBytes(formatter, event);
+            byte[] suffixBytes = doEncodeWrapped(suffix, event);
+            if (lineSeparatorBytes != null && lineSeparatorBytes.length > 0) {
+                suffixBytes = ArrayUtils.addAll(suffixBytes, lineSeparatorBytes);
             }
-            
-            if (immediateFlush) {
-                outputStream.flush();
-            }
-        
+
+            return ArrayUtils.addAll(ArrayUtils.addAll(prefixBytes, bytes), suffixBytes);
         } catch (IOException e) {
             addWarn("Error encountered while encoding log event. "
                     + "OutputStream is now in an unknown state, but will continue to be used for future log events."
                     + "Event: " + event, e);
+            return EMPTY_BYTES;
         }
     }
 
-    private void doEncodeWrapped(Encoder<Event> wrapped, Event event) throws IOException {
-        if (wrapped != null) {
-            wrapped.doEncode(event);
+    private byte[] getEventBytes(CompositeJsonFormatter<Event> formatter, Event event) throws IOException {
+        final String result = formatter.writeEventAsString(event);
+        if (result == null) {
+            return EMPTY_BYTES;
         }
+        return result.getBytes();
     }
-    
+
+    private byte[] doEncodeWrapped(Encoder<Event> encoder, Event event) {
+        if (prefix != null) {
+            return encoder.encode(event);
+        }
+        return EMPTY_BYTES;
+    }
+
+    @Override
+    public byte[] footerBytes() {
+        return EMPTY_BYTES;
+    }
+
     @Override
     public void start() {
         super.start();
@@ -114,17 +122,17 @@ public abstract class CompositeJsonEncoder<Event extends DeferredProcessingAware
         if (wrapped instanceof LayoutWrappingEncoder) {
             /*
              * Convenience hack to ensure the same charset is used in most cases.
-             * 
+             *
              * The charset for other encoders must be configured
              * on the wrapped encoder configuration.
              */
             LayoutWrappingEncoder<Event> layoutWrappedEncoder = (LayoutWrappingEncoder<Event>) wrapped;
             layoutWrappedEncoder.setCharset(charset);
-            
+
             if (layoutWrappedEncoder.getLayout() instanceof PatternLayoutBase) {
                 /*
                  * Don't ensure exception output (for ILoggingEvents)
-                 * or line separation (for IAccessEvents) 
+                 * or line separation (for IAccessEvents)
                  */
                 PatternLayoutBase layout = (PatternLayoutBase) layoutWrappedEncoder.getLayout();
                 layout.setPostCompileProcessor(null);
@@ -136,12 +144,12 @@ public abstract class CompositeJsonEncoder<Event extends DeferredProcessingAware
                 layout.start();
             }
         }
-        
+
         if (wrapped != null && !wrapped.isStarted()) {
             wrapped.start();
         }
     }
-    
+
     @Override
     public void stop() {
         super.stop();
@@ -149,25 +157,13 @@ public abstract class CompositeJsonEncoder<Event extends DeferredProcessingAware
         stopWrapped(prefix);
         stopWrapped(suffix);
     }
-    
+
     private void stopWrapped(Encoder<Event> wrapped) {
         if (wrapped != null && !wrapped.isStarted()) {
             wrapped.stop();
         }
     }
-    
-    @Override
-    public void close() throws IOException {
-        closeWrapped(prefix);
-        closeWrapped(suffix);
-    }
-    
-    private void closeWrapped(Encoder<Event> wrapped) throws IOException {
-        if (wrapped != null && !wrapped.isStarted()) {
-            wrapped.close();
-        }
-    }
-    
+
     public JsonProviders<Event> getProviders() {
         return formatter.getProviders();
     }
@@ -175,15 +171,15 @@ public abstract class CompositeJsonEncoder<Event extends DeferredProcessingAware
     public void setProviders(JsonProviders<Event> jsonProviders) {
         formatter.setProviders(jsonProviders);
     }
-    
+
     public boolean isImmediateFlush() {
         return immediateFlush;
     }
-    
+
     public void setImmediateFlush(boolean immediateFlush) {
         this.immediateFlush = immediateFlush;
     }
-    
+
     public JsonFactoryDecorator getJsonFactoryDecorator() {
         return formatter.getJsonFactoryDecorator();
     }
@@ -195,7 +191,7 @@ public abstract class CompositeJsonEncoder<Event extends DeferredProcessingAware
     public JsonGeneratorDecorator getJsonGeneratorDecorator() {
         return formatter.getJsonGeneratorDecorator();
     }
-    
+
     public String getEncoding() {
         return formatter.getEncoding();
     }
@@ -211,15 +207,15 @@ public abstract class CompositeJsonEncoder<Event extends DeferredProcessingAware
     public void setJsonGeneratorDecorator(JsonGeneratorDecorator jsonGeneratorDecorator) {
         formatter.setJsonGeneratorDecorator(jsonGeneratorDecorator);
     }
-    
+
     public String getLineSeparator() {
         return lineSeparator;
     }
-    
+
     /**
      * Sets which lineSeparator to use between events.
      * <p>
-     * 
+     *
      * The following values have special meaning:
      * <ul>
      * <li><tt>null</tt> or empty string = no new line.</li>
@@ -237,14 +233,14 @@ public abstract class CompositeJsonEncoder<Event extends DeferredProcessingAware
     protected CompositeJsonFormatter<Event> getFormatter() {
         return formatter;
     }
-    
+
     public Encoder<Event> getPrefix() {
         return prefix;
     }
     public void setPrefix(Encoder<Event> prefix) {
         this.prefix = prefix;
     }
-    
+
     public Encoder<Event> getSuffix() {
         return suffix;
     }

--- a/src/test/java/net/logstash/logback/ConfigurationTest.java
+++ b/src/test/java/net/logstash/logback/ConfigurationTest.java
@@ -164,11 +164,11 @@ public class ConfigurationTest {
         LoggingEventPatternJsonProvider patternProvider = getInstance(providers, LoggingEventPatternJsonProvider.class);
         Assert.assertEquals("{\"patternName\":\"patternValue\",\"relativeTime\":\"#asLong{%relative}\"}", patternProvider.getPattern());
         Assert.assertNotNull(patternProvider);
-        
+
         LoggingEventNestedJsonProvider nestedJsonProvider = getInstance(providers, LoggingEventNestedJsonProvider.class);
         Assert.assertNotNull(nestedJsonProvider);
         Assert.assertEquals("nested", nestedJsonProvider.getFieldName());
-        
+
         RawMessageJsonProvider rawMessageJsonProvider = getInstance(nestedJsonProvider.getProviders().getProviders(), RawMessageJsonProvider.class);
         Assert.assertNotNull(rawMessageJsonProvider);
         Assert.assertEquals("customRawMessage", rawMessageJsonProvider.getFieldName());
@@ -197,9 +197,7 @@ public class ConfigurationTest {
                 });
 
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        encoder.init(outputStream);
-        encoder.doEncode(listAppender.list.get(0));
-        
+        outputStream.write(encoder.encode(listAppender.list.get(0)));
 
         Map<String, Object> output = parseJson(outputStream.toString("UTF-8"));
         Assert.assertNotNull(output.get("@timestamp"));

--- a/src/test/java/net/logstash/logback/appender/LogstashTcpSocketAppenderTest.java
+++ b/src/test/java/net/logstash/logback/appender/LogstashTcpSocketAppenderTest.java
@@ -123,9 +123,7 @@ public class LogstashTcpSocketAppenderTest {
         
         verify(event1).getCallerData();
         
-        verify(encoder, timeout(VERIFICATION_TIMEOUT)).init(any(OutputStream.class));
-        
-        verify(encoder, timeout(VERIFICATION_TIMEOUT)).doEncode(event1);
+        verify(encoder, timeout(VERIFICATION_TIMEOUT)).encode(event1);
     }
 
     @Test
@@ -144,9 +142,7 @@ public class LogstashTcpSocketAppenderTest {
         
         appender.append(event1);
         
-        verify(encoder, timeout(VERIFICATION_TIMEOUT)).init(any(OutputStream.class));
-        
-        verify(encoder, timeout(VERIFICATION_TIMEOUT)).doEncode(event1);
+        verify(encoder, timeout(VERIFICATION_TIMEOUT)).encode(event1);
     }
 
     @Test
@@ -158,13 +154,11 @@ public class LogstashTcpSocketAppenderTest {
         
         verify(encoder).start();
         
-        doThrow(new SocketException()).doNothing().when(encoder).doEncode(event1);
+        doThrow(new SocketException()).doNothing().when(encoder).encode(event1);
         
         appender.append(event1);
         
-        verify(encoder, timeout(VERIFICATION_TIMEOUT).times(2)).init(any(OutputStream.class));
-        
-        verify(encoder, timeout(VERIFICATION_TIMEOUT).times(2)).doEncode(event1);
+        verify(encoder, timeout(VERIFICATION_TIMEOUT).times(2)).encode(event1);
     }
 
     @Test
@@ -189,9 +183,7 @@ public class LogstashTcpSocketAppenderTest {
         
         appender.append(event1);
         
-        verify(encoder, timeout(VERIFICATION_TIMEOUT).times(2)).init(any(OutputStream.class));
-        
-        verify(encoder, timeout(VERIFICATION_TIMEOUT)).doEncode(event1);
+        verify(encoder, timeout(VERIFICATION_TIMEOUT)).encode(event1);
     }
 
 
@@ -276,7 +268,7 @@ public class LogstashTcpSocketAppenderTest {
         // and attempt to reconnect starting from the first host of the list.
         doThrow(new SocketException())
             .doNothing()
-            .when(encoder).doEncode(event1);
+            .when(encoder).encode(event1);
         
         
         // Start the appender and verify it is actually started
@@ -341,7 +333,7 @@ public class LogstashTcpSocketAppenderTest {
         inOrder.verify(socket).connect(host("localhost", 10001), anyInt());
 
         // 3) send the event
-        inOrder.verify(encoder).doEncode(event1);
+        inOrder.verify(encoder).encode(event1);
 
         // 4) connect to primary
         inOrder.verify(socket).connect(host("localhost", 10000), anyInt());

--- a/src/test/java/net/logstash/logback/encoder/CompositeJsonEncoderTest.java
+++ b/src/test/java/net/logstash/logback/encoder/CompositeJsonEncoderTest.java
@@ -82,12 +82,10 @@ public class CompositeJsonEncoderTest {
         
         verify(formatter).setContext(context);
         verify(formatter).start();
+
+        outputStream.write(encoder.encode(event));
         
-        encoder.init(outputStream);
-        
-        encoder.doEncode(event);
-        
-        verify(formatter).writeEventToOutputStream(event, outputStream);
+        verify(formatter).writeEventAsString(event);
         
         Assert.assertEquals(System.getProperty("line.separator"), outputStream.toString("UTF-8"));
         
@@ -116,23 +114,14 @@ public class CompositeJsonEncoderTest {
         verify(prefix).start();
         verify(suffix).start();
         
-        encoder.init(outputStream);
+        outputStream.write(encoder.encode(event));
         
-        verify(prefix).init(outputStream);
-        verify(suffix).init(outputStream);
+        verify(prefix).encode(event);
+        verify(suffix).encode(event);
         
-        encoder.doEncode(event);
-        
-        verify(prefix).doEncode(event);
-        verify(suffix).doEncode(event);
-        
-        verify(formatter).writeEventToOutputStream(event, outputStream);
+        verify(formatter).writeEventAsString(event);
         
         Assert.assertEquals(System.getProperty("line.separator"), outputStream.toString("UTF-8"));
-        
-        encoder.close();
-        verify(prefix).close();
-        verify(suffix).close();
         
         encoder.stop();
         Assert.assertFalse(encoder.isStarted());
@@ -153,11 +142,9 @@ public class CompositeJsonEncoderTest {
         verify(formatter).setContext(context);
         verify(formatter).start();
         
-        encoder.init(bufferedOutputStream);
+        outputStream.write(encoder.encode(event));
         
-        encoder.doEncode(event);
-        
-        verify(formatter).writeEventToOutputStream(event, bufferedOutputStream);
+        verify(formatter).writeEventAsString(event);
         
         Assert.assertEquals("", outputStream.toString("UTF-8"));
         
@@ -204,12 +191,10 @@ public class CompositeJsonEncoderTest {
         verify(formatter).setContext(context);
         verify(formatter).start();
         
-        encoder.init(outputStream);
-        
         IOException exception = new IOException();
-        doThrow(exception).when(formatter).writeEventToOutputStream(event, outputStream);
+        doThrow(exception).when(formatter).writeEventAsString(event);
         
-        encoder.doEncode(event);
+        outputStream.write(encoder.encode(event));
         
         Assert.assertTrue(encoder.isStarted());
         

--- a/src/test/java/net/logstash/logback/encoder/LogstashAccessEncoderTest.java
+++ b/src/test/java/net/logstash/logback/encoder/LogstashAccessEncoderTest.java
@@ -43,7 +43,6 @@ public class LogstashAccessEncoderTest {
     public void before() throws Exception {
         outputStream = new ByteArrayOutputStream();
         encoder = new LogstashAccessEncoder();
-        encoder.init(outputStream);
     }
     
     @Test
@@ -56,7 +55,7 @@ public class LogstashAccessEncoderTest {
         encoder.getFieldNames().setTimestamp("timestamp");
         
         encoder.start();
-        encoder.doEncode(event);
+        outputStream.write(encoder.encode(event));
         closeQuietly(outputStream);
         
         JsonNode node = MAPPER.readTree(outputStream.toByteArray());
@@ -89,8 +88,7 @@ public class LogstashAccessEncoderTest {
         IAccessEvent event = mockBasicILoggingEvent();
         
         encoder.start();
-        encoder.doEncode(event);
-        encoder.close();
+        outputStream.write(encoder.encode(event));
         closeQuietly(outputStream);
         
         assertThat(outputStream.toString()).endsWith(LINE_SEPARATOR);
@@ -109,7 +107,7 @@ public class LogstashAccessEncoderTest {
         
         encoder.setContext(context);
         encoder.start();
-        encoder.doEncode(event);
+        outputStream.write(encoder.encode(event));
         closeQuietly(outputStream);
         
         JsonNode node = MAPPER.readTree(outputStream.toByteArray());
@@ -125,7 +123,7 @@ public class LogstashAccessEncoderTest {
         encoder.getFieldNames().setFieldsRequestHeaders("@fields.request_headers");
         encoder.getFieldNames().setFieldsResponseHeaders("@fields.response_headers");
         encoder.start();
-        encoder.doEncode(event);
+        outputStream.write(encoder.encode(event));
         closeQuietly(outputStream);
         
         JsonNode node = MAPPER.readTree(outputStream.toByteArray());

--- a/src/test/java/net/logstash/logback/encoder/LogstashEncoderTest.java
+++ b/src/test/java/net/logstash/logback/encoder/LogstashEncoderTest.java
@@ -76,7 +76,6 @@ public class LogstashEncoderTest {
     public void before() throws Exception {
         outputStream = new ByteArrayOutputStream();
         encoder = new LogstashEncoder();
-        encoder.init(outputStream);
     }
     
     @Test
@@ -87,7 +86,7 @@ public class LogstashEncoderTest {
         when(event.getTimeStamp()).thenReturn(timestamp);
         
         encoder.start();
-        encoder.doEncode(event);
+        outputStream.write(encoder.encode(event));
         closeQuietly(outputStream);
         
         JsonNode node = MAPPER.readTree(outputStream.toByteArray());
@@ -110,7 +109,7 @@ public class LogstashEncoderTest {
         when(event.getTimeStamp()).thenReturn(timestamp);
         encoder.setFieldNames(new ShortenedFieldNames());
         encoder.start();
-        encoder.doEncode(event);
+        outputStream.write(encoder.encode(event));
         closeQuietly(outputStream);
         
         JsonNode node = MAPPER.readTree(outputStream.toByteArray());
@@ -150,7 +149,7 @@ public class LogstashEncoderTest {
         ILoggingEvent event = mockBasicILoggingEvent(Level.ERROR);
         when(event.getTimeStamp()).thenReturn(timestamp);
         
-        encoder.doEncode(event);
+        outputStream.write(encoder.encode(event));
         closeQuietly(outputStream);
         
         String output = outputStream.toString("UTF-8");
@@ -181,7 +180,7 @@ public class LogstashEncoderTest {
         encoder.setFieldNames(new ShortenedFieldNames());
         encoder.setShortenedLoggerNameLength(length);
         encoder.start();
-        encoder.doEncode(event);
+        outputStream.write(encoder.encode(event));
         closeQuietly(outputStream);
 
         JsonNode node = MAPPER.readTree(outputStream.toByteArray());
@@ -201,8 +200,7 @@ public class LogstashEncoderTest {
         ILoggingEvent event = mockBasicILoggingEvent(Level.ERROR);
         
         encoder.start();
-        encoder.doEncode(event);
-        encoder.close();
+        outputStream.write(encoder.encode(event));
         closeQuietly(outputStream);
         
         assertThat(outputStream.toString()).endsWith(LINE_SEPARATOR);
@@ -216,7 +214,7 @@ public class LogstashEncoderTest {
         when(event.getThrowableProxy()).thenReturn(throwableProxy);
         
         encoder.start();
-        encoder.doEncode(event);
+        outputStream.write(encoder.encode(event));
         closeQuietly(outputStream);
         
         JsonNode node = MAPPER.readTree(outputStream.toByteArray());
@@ -234,7 +232,7 @@ public class LogstashEncoderTest {
         when(event.getMDCPropertyMap()).thenReturn(mdcMap);
         
         encoder.start();
-        encoder.doEncode(event);
+        outputStream.write(encoder.encode(event));
         closeQuietly(outputStream);
         
         JsonNode node = MAPPER.readTree(outputStream.toByteArray());
@@ -255,7 +253,7 @@ public class LogstashEncoderTest {
         encoder.addIncludeMdcKeyName("thing_one");
         
         encoder.start();
-        encoder.doEncode(event);
+        outputStream.write(encoder.encode(event));
         closeQuietly(outputStream);
         
         JsonNode node = MAPPER.readTree(outputStream.toByteArray());
@@ -276,7 +274,7 @@ public class LogstashEncoderTest {
         encoder.addExcludeMdcKeyName("thing_two");
         
         encoder.start();
-        encoder.doEncode(event);
+        outputStream.write(encoder.encode(event));
         closeQuietly(outputStream);
         
         JsonNode node = MAPPER.readTree(outputStream.toByteArray());
@@ -296,7 +294,7 @@ public class LogstashEncoderTest {
         
         encoder.setIncludeMdc(false);
         encoder.start();
-        encoder.doEncode(event);
+        outputStream.write(encoder.encode(event));
         closeQuietly(outputStream);
         
         JsonNode node = MAPPER.readTree(outputStream.toByteArray());
@@ -316,7 +314,7 @@ public class LogstashEncoderTest {
         
         encoder.getFieldNames().setMdc("mdc");
         encoder.start();
-        encoder.doEncode(event);
+        outputStream.write(encoder.encode(event));
         closeQuietly(outputStream);
         
         JsonNode node = MAPPER.readTree(outputStream.toByteArray());
@@ -331,7 +329,7 @@ public class LogstashEncoderTest {
         when(event.getMDCPropertyMap()).thenReturn(null);
         
         encoder.start();
-        encoder.doEncode(event);
+        outputStream.write(encoder.encode(event));
         closeQuietly(outputStream);
     }
     
@@ -345,7 +343,7 @@ public class LogstashEncoderTest {
         encoder.setIncludeCallerInfo(true);
         
         encoder.start();
-        encoder.doEncode(event);
+        outputStream.write(encoder.encode(event));
         closeQuietly(outputStream);
         
         JsonNode node = MAPPER.readTree(outputStream.toByteArray());
@@ -366,7 +364,7 @@ public class LogstashEncoderTest {
         encoder.setIncludeCallerInfo(true);
         encoder.getFieldNames().setCaller("caller");
         encoder.start();
-        encoder.doEncode(event);
+        outputStream.write(encoder.encode(event));
         closeQuietly(outputStream);
         
         JsonNode node = MAPPER.readTree(outputStream.toByteArray());
@@ -391,7 +389,7 @@ public class LogstashEncoderTest {
         encoder.setIncludeCallerInfo(false);
         
         encoder.start();
-        encoder.doEncode(event);
+        outputStream.write(encoder.encode(event));
         closeQuietly(outputStream);
         
         JsonNode node = MAPPER.readTree(outputStream.toByteArray());
@@ -414,7 +412,7 @@ public class LogstashEncoderTest {
         
         encoder.setContext(context);
         encoder.start();
-        encoder.doEncode(event);
+        outputStream.write(encoder.encode(event));
         closeQuietly(outputStream);
         
         JsonNode node = MAPPER.readTree(outputStream.toByteArray());
@@ -436,7 +434,7 @@ public class LogstashEncoderTest {
         encoder.setIncludeContext(false);
         encoder.setContext(context);
         encoder.start();
-        encoder.doEncode(event);
+        outputStream.write(encoder.encode(event));
         closeQuietly(outputStream);
         
         JsonNode node = MAPPER.readTree(outputStream.toByteArray());
@@ -459,7 +457,7 @@ public class LogstashEncoderTest {
         encoder.getFieldNames().setContext("context");
         encoder.setContext(context);
         encoder.start();
-        encoder.doEncode(event);
+        outputStream.write(encoder.encode(event));
         closeQuietly(outputStream);
         
         JsonNode node = MAPPER.readTree(outputStream.toByteArray());
@@ -475,7 +473,7 @@ public class LogstashEncoderTest {
         when(event.getMarker()).thenReturn(marker);
         
         encoder.start();
-        encoder.doEncode(event);
+        outputStream.write(encoder.encode(event));
         closeQuietly(outputStream);
         
         JsonNode node = MAPPER.readTree(outputStream.toByteArray());
@@ -491,7 +489,7 @@ public class LogstashEncoderTest {
         when(event.getMarker()).thenReturn(marker);
         
         encoder.start();
-        encoder.doEncode(event);
+        outputStream.write(encoder.encode(event));
         closeQuietly(outputStream);
         
         JsonNode node = MAPPER.readTree(outputStream.toByteArray());
@@ -505,7 +503,7 @@ public class LogstashEncoderTest {
         when(event.getMarker()).thenReturn(null);
         
         encoder.start();
-        encoder.doEncode(event);
+        outputStream.write(encoder.encode(event));
         closeQuietly(outputStream);
         
         JsonNode node = MAPPER.readTree(outputStream.toByteArray());
@@ -528,7 +526,7 @@ public class LogstashEncoderTest {
         when(event.getArgumentArray()).thenReturn(argArray);
         
         encoder.start();
-        encoder.doEncode(event);
+        outputStream.write(encoder.encode(event));
         closeQuietly(outputStream);
         
         JsonNode node = MAPPER.readTree(outputStream.toByteArray());
@@ -545,7 +543,7 @@ public class LogstashEncoderTest {
         when(event.getArgumentArray()).thenReturn(argArray);
         
         encoder.start();
-        encoder.doEncode(event);
+        outputStream.write(encoder.encode(event));
         closeQuietly(outputStream);
         
         JsonNode node = MAPPER.readTree(outputStream.toByteArray());
@@ -569,7 +567,7 @@ public class LogstashEncoderTest {
         
         encoder.setCustomFields(customFields);
         encoder.start();
-        encoder.doEncode(event);
+        outputStream.write(encoder.encode(event));
         closeQuietly(outputStream);
         
         JsonNode node = MAPPER.readTree(outputStream.toByteArray());
@@ -588,7 +586,7 @@ public class LogstashEncoderTest {
         
         encoder.setTimeZone("UTC");
         encoder.start();
-        encoder.doEncode(event);
+        outputStream.write(encoder.encode(event));
         closeQuietly(outputStream);
         
         JsonNode node = MAPPER.readTree(outputStream.toByteArray());
@@ -615,7 +613,7 @@ public class LogstashEncoderTest {
         
         encoder.setEnableContextMap(true);
         encoder.start();
-        encoder.doEncode(event);
+        outputStream.write(encoder.encode(event));
         closeQuietly(outputStream);
         
         JsonNode node = MAPPER.readTree(outputStream.toByteArray());
@@ -647,7 +645,7 @@ public class LogstashEncoderTest {
         
         encoder.setEnableContextMap(true);
         encoder.start();
-        encoder.doEncode(event);
+        outputStream.write(encoder.encode(event));
         closeQuietly(outputStream);
         
         JsonNode node = MAPPER.readTree(outputStream.toByteArray());
@@ -682,7 +680,7 @@ public class LogstashEncoderTest {
         when(event.getMarker()).thenReturn(marker);
         
         encoder.start();
-        encoder.doEncode(event);
+        outputStream.write(encoder.encode(event));
         closeQuietly(outputStream);
         
         JsonNode node = MAPPER.readTree(outputStream.toByteArray());


### PR DESCRIPTION
Here is PR for #205.

Some tests are still failed, see the report below.

> Failed tests:   testNoImmediateFlush(net.logstash.logback.encoder.CompositeJsonEncoderTest): expected:<[]> but was:<[(..)
  testReconnectOnReadFailure(net.logstash.logback.appender.LogstashTcpSocketAppenderTest): (..)
  testReconnectOnOpen(net.logstash.logback.appender.LogstashTcpSocketAppenderTest): (..)
  testEncoderCalled(net.logstash.logback.appender.LogstashTcpSocketAppenderTest): (..)
  testReconnectToPrimaryWhileOnSecondary(net.logstash.logback.appender.LogstashTcpSocketAppenderTest): (..)

> Tests in error: 
  testReconnectOnWrite(net.logstash.logback.appender.LogstashTcpSocketAppenderTest): (..)
  testReconnectToSecondaryOnWrite(net.logstash.logback.appender.LogstashTcpSocketAppenderTest): (..)
Tests run: 208, Failures: 5, Errors: 2, Skipped: 0