### PR TITLE
Added support for #asJson #208

### DIFF
--- a/README.md
+++ b/README.md
@@ -1605,7 +1605,9 @@ So this example...
 <pattern>
   {
     "bytes_sent_str": "%b",
-    "bytes_sent_long": "#asLong{%b}"
+    "bytes_sent_long": "#asLong{%b}",
+    "has_message": "#asJson(%X{hasMessage})",
+    "raw_message: "#asJson(%m)"
   }
 </pattern>
 ```
@@ -1614,7 +1616,9 @@ So this example...
 ```
 {
   "bytes_sent_str": "1024",
-  "bytes_sent_long": 1024
+  "bytes_sent_long": 1024,
+  "has_message": true,
+  "raw_message": { "type":"example", "msg":"example of json message with type" }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1597,6 +1597,7 @@ The operations are:
 
 * `#asLong{...}` - evaluates the pattern in curly braces and then converts resulting string to a long (or a null if conversion fails).
 * `#asDouble{...}` - evaluates the pattern in curly braces and then converts resulting string to a double (or a null if conversion fails).
+* `#asJson{...}` - evaluates the pattern in curly braces and then converts resulting string to json (or a null if conversion fails).
 
 So this example...
 

--- a/src/test/java/net/logstash/logback/pattern/AbstractJsonPatternParserTest.java
+++ b/src/test/java/net/logstash/logback/pattern/AbstractJsonPatternParserTest.java
@@ -206,48 +206,30 @@ public abstract class AbstractJsonPatternParserTest<Event> {
     }
 
     @Test
-    public void asJsonShouldTransformTextValueToJsonArray() throws IOException {
+    public void asJsonShouldTransformTextValueToJson() throws IOException {
 
         String pattern = ""
                 + "{\n"
-                + "    \"key1\": \"#asJson{[1, 2]}\"\n"
+                + "    \"key1\": \"#asJson{true}\",\n"
+                + "    \"key2\": \"#asJson{123}\",\n"
+                + "    \"key3\": \"#asJson{123.4}\",\n"
+                + "    \"key4\": \"#asJson{\\\"123\\\"}\",\n"
+                + "    \"key5\": \"#asJson{[1, 2]}\",\n"
+                + "    \"key6\": \"#asJson{[1, \\\"2\\\"]}\",\n"
+                + "    \"key7\": \"#asJson{{\\\"field\\\":\\\"value\\\"}}\",\n"
+                + "    \"key8\": \"#asJson{{\\\"field\\\":\\\"value\\\",\\\"num\\\":123}}\"\n"
                 + "}";
 
         String expected = ""
                 + "{\n"
-                + "    \"key1\": [1, 2]\n"
-                + "}";
-
-        verifyFields(pattern, expected);
-    }
-
-    @Test
-    public void asJsonShouldTransformTextValueToJsonObject() throws IOException {
-
-        String pattern = ""
-                + "{\n"
-                + "    \"key2\": \"#asJson{{\\\"k\\\":\\\"v\\\"}}\"\n"
-                + "}";
-
-        String expected = ""
-                + "{\n"
-                + "    \"key2\": {\"k\":\"v\"}\n"
-                + "}";
-
-        verifyFields(pattern, expected);
-    }
-
-    @Test
-    public void asJsonShouldTransformTextValueToJsonError() throws IOException {
-
-        String pattern = ""
-                + "{\n"
-                + "    \"key2\": \"#asJson{{\\\"k\\\":\\\"v}}\"\n"
-                + "}";
-
-        String expected = ""
-                + "{\n"
-                + "    \"key2\": null\n"
+                + "    \"key1\": true,\n"
+                + "    \"key2\": 123,\n"
+                + "    \"key3\": 123.4,\n"
+                + "    \"key4\": \"123\",\n"
+                + "    \"key5\": [1, 2],\n"
+                + "    \"key6\": [1, \"2\"],\n"
+                + "    \"key7\": {\"field\":\"value\"},\n"
+                + "    \"key8\": {\"field\":\"value\", \"num\":123}\n"
                 + "}";
 
         verifyFields(pattern, expected);
@@ -260,14 +242,16 @@ public abstract class AbstractJsonPatternParserTest<Event> {
                 + "{\n"
                 + "    \"key1\": \"#asLong{abc}\",\n"
                 + "    \"key2\": \"test\",\n"
-                + "    \"key3\": \"#asDouble{abc}\"\n"
+                + "    \"key3\": \"#asDouble{abc}\",\n"
+                + "    \"key4\": \"#asJson{[1, 2}\"\n"
                 + "}";
 
         String expected = ""
                 + "{\n"
                 + "    \"key1\": null,\n"
                 + "    \"key2\": \"test\",\n"
-                + "    \"key3\": null\n"
+                + "    \"key3\": null,\n"
+                + "    \"key4\": null\n"
                 + "}";
 
         verifyFields(pattern, expected);
@@ -280,14 +264,16 @@ public abstract class AbstractJsonPatternParserTest<Event> {
                 + "{\n"
                 + "    \"key1\": \"#asDouble{0\",\n"
                 + "    \"key2\": \"#asDouble\",\n"
-                + "    \"key3\": \"#something\"\n"
+                + "    \"key3\": \"#something\",\n"
+                + "    \"key4\": \"#asJson{[1, 2]\"\n"
                 + "}";
 
         String expected = ""
                 + "{\n"
                 + "    \"key1\": \"#asDouble{0\",\n"
                 + "    \"key2\": \"#asDouble\",\n"
-                + "    \"key3\": \"#something\"\n"
+                + "    \"key3\": \"#something\",\n"
+                + "    \"key4\": \"#asJson{[1, 2]\"\n"
                 + "}";
 
         verifyFields(pattern, expected);

--- a/src/test/java/net/logstash/logback/pattern/AbstractJsonPatternParserTest.java
+++ b/src/test/java/net/logstash/logback/pattern/AbstractJsonPatternParserTest.java
@@ -206,6 +206,54 @@ public abstract class AbstractJsonPatternParserTest<Event> {
     }
 
     @Test
+    public void asJsonShouldTransformTextValueToJsonArray() throws IOException {
+
+        String pattern = ""
+                + "{\n"
+                + "    \"key1\": \"#asJson{[1, 2]}\"\n"
+                + "}";
+
+        String expected = ""
+                + "{\n"
+                + "    \"key1\": [1, 2]\n"
+                + "}";
+
+        verifyFields(pattern, expected);
+    }
+
+    @Test
+    public void asJsonShouldTransformTextValueToJsonObject() throws IOException {
+
+        String pattern = ""
+                + "{\n"
+                + "    \"key2\": \"#asJson{{\\\"k\\\":\\\"v\\\"}}\"\n"
+                + "}";
+
+        String expected = ""
+                + "{\n"
+                + "    \"key2\": {\"k\":\"v\"}\n"
+                + "}";
+
+        verifyFields(pattern, expected);
+    }
+
+    @Test
+    public void asJsonShouldTransformTextValueToJsonError() throws IOException {
+
+        String pattern = ""
+                + "{\n"
+                + "    \"key2\": \"#asJson{{\\\"k\\\":\\\"v}}\"\n"
+                + "}";
+
+        String expected = ""
+                + "{\n"
+                + "    \"key2\": null\n"
+                + "}";
+
+        verifyFields(pattern, expected);
+    }
+
+    @Test
     public void shouldSendNonTransformableValuesAsNulls() throws IOException {
 
         String pattern = ""


### PR DESCRIPTION
Hi, I have added support for using #asJson issue: #208 
It's useful specially when using with message:

```xml
<encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
    <providers>
        <pattern><pattern>{jsonMessage: "#asJson{%m}"}</pattern></pattern>
        ...
    </providers>
</encoder>
```