### PR TITLE
Update Jackson version to 2.8.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <ch.qos.logback.version>1.2.3</ch.qos.logback.version>
-        <com.fasterxml.jackson.version>2.8.8</com.fasterxml.jackson.version>
+        <com.fasterxml.jackson.version>2.8.9</com.fasterxml.jackson.version>
         <com.fasterxml.uuid.version>3.1.4</com.fasterxml.uuid.version>
         <commons.io.version>2.4</commons.io.version>
         <commons.lang.version>2.6</commons.lang.version>


### PR DESCRIPTION
Addresses Jackson Deserializer security vulnerability. Refer issue #230 