### PR TITLE
TurboFilter which puts Exception class names into fields

### DIFF
--- a/src/main/java/net/logstash/logback/turbo/ThrowableAsField.java
+++ b/src/main/java/net/logstash/logback/turbo/ThrowableAsField.java
@@ -1,0 +1,76 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.logstash.logback.turbo;
+
+import org.slf4j.MDC;
+import org.slf4j.Marker;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.turbo.TurboFilter;
+import ch.qos.logback.core.spi.FilterReply;
+
+/**
+ * Adds two fields to MDC which contain (cause) exception class names.
+ */
+public class ThrowableAsField extends TurboFilter {
+
+    static final String FIELD_NAME = "throwable_class";
+    static final String FIELD_NAME_CAUSE = "throwable_cause_class";
+
+    @Override
+    public FilterReply decide(Marker marker, Logger logger, Level level, String format, Object[] params, Throwable t) {
+        // performance optimization
+        if (t == null && (params == null || params.length == 0) || MDC.get(FIELD_NAME) != null) {
+            return FilterReply.NEUTRAL;
+        }
+
+        Throwable throwable = t != null ? t : extractThrowableFromParams(params);
+        if (throwable == null) {
+            return FilterReply.NEUTRAL;
+        }
+
+        MDC.put(FIELD_NAME, throwable.getClass().getSimpleName());
+        try {
+
+            if (throwable.getCause() != null) {
+                MDC.put(FIELD_NAME_CAUSE, getCause(throwable).getClass().getSimpleName());
+            }
+
+            logger.log(marker, logger.getName(), Level.toLocationAwareLoggerInteger(level), format, params, t);
+            return FilterReply.DENY;
+
+        } finally {
+            MDC.remove(FIELD_NAME);
+            MDC.remove(FIELD_NAME_CAUSE);
+        }
+    }
+
+    /** @return null if no throwable in params */
+    private static Throwable extractThrowableFromParams(Object[] params) {
+        for (Object param : params) {
+            if (param instanceof Throwable) {
+                return (Throwable) param;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @return given throwable if t does not contain any cause
+     */
+    private static Throwable getCause(Throwable t) {
+        return t.getCause() != null ? getCause(t.getCause()) : t;
+    }
+}

--- a/src/test/java/net/logstash/logback/turbo/ThrowableAsFieldIT.java
+++ b/src/test/java/net/logstash/logback/turbo/ThrowableAsFieldIT.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.logstash.logback.turbo;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.*;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+
+import org.junit.*;
+import org.slf4j.LoggerFactory;
+
+public class ThrowableAsFieldIT {
+    private ByteArrayOutputStream logOutput;
+    private PrintStream actualSystemOut;
+
+    @Before
+    public void setUp() {
+        actualSystemOut = System.out;
+        logOutput = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(logOutput));
+    }
+
+    @After
+    public void cleanUp() {
+        System.setOut(actualSystemOut);
+        System.out.println(logOutput.toString());
+    }
+
+    @Test
+    public void test() throws InterruptedException {
+        LoggerFactory.getLogger(this.getClass()).info("message without exception");
+        LoggerFactory.getLogger(this.getClass()).info("message with exception", new IllegalArgumentException());
+        LoggerFactory.getLogger(this.getClass()).info("message with nested exception",
+                new RuntimeException(new IOException(new IllegalArgumentException())));
+
+        assertThat(logOutput.toString(), containsString("[] message without exception"));
+        assertThat(logOutput.toString(),
+                containsString("[throwable_class=IllegalArgumentException] message with exception"));
+        assertThat(logOutput.toString(), containsString(
+                "[throwable_class=RuntimeException, throwable_cause_class=IllegalArgumentException] message with nested exception"));
+    }
+}

--- a/src/test/java/net/logstash/logback/turbo/ThrowableAsFieldTest.java
+++ b/src/test/java/net/logstash/logback/turbo/ThrowableAsFieldTest.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.logstash.logback.turbo;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.*;
+
+import org.junit.*;
+import org.slf4j.MDC;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.turbo.TurboFilter;
+import ch.qos.logback.core.spi.FilterReply;
+
+public class ThrowableAsFieldTest {
+    private final TurboFilter filter = new ThrowableAsField();
+    private final LoggerContext context = new LoggerContext();
+
+    private FilterReply filter(Throwable t) {
+        return filter.decide(null, context.getLogger("loggerName"), Level.INFO, "message", null, t);
+    }
+
+    /** if new message is logged with fields is untestable because Logger is not mockable */
+    @Test
+    public void addExceptionClassToMdc() {
+        assertThat(filter(new IllegalStateException()), equalTo(FilterReply.DENY));
+    }
+
+    /** if new message is logged with fields is untestable because Logger is not mockable */
+    @Test
+    public void addExceptionCauseClassToMdc() {
+        assertThat(filter(new IllegalStateException(new IllegalArgumentException())), equalTo(FilterReply.DENY));
+    }
+
+    @Test
+    public void removeExceptionClassesFromMdc() {
+        assertThat(filter(new IllegalStateException()), equalTo(FilterReply.DENY));
+        assertTrue(MDC.getCopyOfContextMap().isEmpty());
+    }
+
+    @Test
+    public void ignoreIfNoException() {
+        assertThat(filter(null), equalTo(FilterReply.NEUTRAL));
+    }
+
+    @Test
+    public void ignoreIfAlreadyContainsExceptionClass() {
+        MDC.put(ThrowableAsField.FIELD_NAME, "name");
+        try {
+            assertThat(filter(null), equalTo(FilterReply.NEUTRAL));
+        } finally {
+            MDC.remove(ThrowableAsField.FIELD_NAME);
+        }
+    }
+
+    @Test
+    public void logIfExceptionIsParameter() {
+        assertThat(filter.decide(null, context.getLogger("loggerName"), Level.INFO, "message",
+                new Object[] { new IllegalArgumentException() }, null), equalTo(FilterReply.DENY));
+    }
+}

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration debug="true">
     <contextName>testContext</contextName>
+
+    <turboFilter class="net.logstash.logback.turbo.ThrowableAsField"/>
+
     <appender name="stash" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>info</level>
@@ -149,6 +152,12 @@
         </encoder>
     </appender>
     <appender name="listAppender" class="ch.qos.logback.core.read.ListAppender"/>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <Pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} - [%X] %msg%n</Pattern>
+        </encoder>
+    </appender>
+
     <logger name="net.logstash.logback.encoder.LogstashEncoderTest" level="DEBUG">
         <appender-ref ref="stash" />
     </logger>
@@ -156,5 +165,8 @@
         <appender-ref ref="loggingEventCompositeJsonEncoderAppender" />
         <appender-ref ref="logstashEncoderAppender" />
         <appender-ref ref="listAppender" />
+    </logger>
+    <logger name="net.logstash.logback.turbo.ThrowableAsFieldIT" level="DEBUG">
+        <appender-ref ref="STDOUT" />
     </logger>
 </configuration>


### PR DESCRIPTION
add TurboFilter which puts the Throwable class name (actual and root cause) into fields so they can be listed/searched easily in ELK