### PR TITLE
Update com.fasterxml.jackson version to 2.8.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <ch.qos.logback.version>1.2.3</ch.qos.logback.version>
-        <com.fasterxml.jackson.version>2.8.9</com.fasterxml.jackson.version>
+        <com.fasterxml.jackson.version>2.8.11</com.fasterxml.jackson.version>
         <com.fasterxml.uuid.version>3.1.4</com.fasterxml.uuid.version>
         <commons.io.version>2.4</commons.io.version>
         <commons.lang.version>2.6</commons.lang.version>


### PR DESCRIPTION
com.fasterxml.jackson had a security vulnerability labeled CVE-2017-15095. It was addressed in com.fasterxml.jackson versions 2.8.10 and 2.9.1 and later. This commit updates the logback encoder plugin to the latest 2.8.x version of com.fasterxml.jackson to address that.