### PR TITLE
master: Added post socket connect hook for post authorization

### DIFF
--- a/src/main/java/net/logstash/logback/appender/AbstractLogstashTcpSocketAppender.java
+++ b/src/main/java/net/logstash/logback/appender/AbstractLogstashTcpSocketAppender.java
@@ -562,6 +562,8 @@ public abstract class AbstractLogstashTcpSocketAppender<Event extends DeferredPr
                         updateCurrentThreadName();
                     }
                     
+                    afterSocketOpen(socket);
+
                     this.readerFuture = scheduleReaderRunnable(
                             new ReaderRunnable(tempSocket.getInputStream()));
 
@@ -1154,4 +1156,8 @@ public abstract class AbstractLogstashTcpSocketAppender<Event extends DeferredPr
         this.connectionStrategy = destinationConnectionStrategy;
     }
 
+
+    protected void afterSocketOpen(Socket socket) throws Exception {
+        //implement action after the socket was opened
+    }
 }


### PR DESCRIPTION
I implemented a logmet (lumberjack protocol) encoder wrapper and appender for IBM Bluemix that relies heavily on logstash's marvelous work. 
There is however one obstacle I want to remove with this humple pull request. IBM/softlayer's security does not rely on certificates and trust, but on a API key which must be past after the socket connection was established. The very good implementation of `AbstractLogstashTcpSocketAppender` does not allow extension of a after connection callback which I so dearly need.
I hope you will accept this pull request, since it does not change the logic in any way and would allow me use logstash out of the box instead of shadowing the `AbstractLogstashTcpSocketAppender` class.