### PR TITLE
Unix timestamp support for LogstashEncoder and LogstashAccessEncoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1156,8 +1156,14 @@ You can change the timezone like this:
 ```
 
 The value of the `timeZone` element can be any string accepted by java's  `TimeZone.getTimeZone(String id)` method.
+It is also possible generate `@timestamp` as a unix timestamp using following configuration:
 
-
+```
+<encoder class="net.logstash.logback.encoder.LogstashEncoder">
+  <unixTimestamp>true</unixTimestamp>
+</encoder>
+```
+An output will looks like `"@timestamp":"1524597357413"`.
 
 ## Customizing JSON Factory and Generator
 
@@ -1590,6 +1596,7 @@ For AccessEvents, the available providers and their configuration properties (de
           <li><tt>fieldName</tt> - Output field name (<tt>@timestamp</tt>)</li>
           <li><tt>pattern</tt> - Output format (<tt>yyyy-MM-dd'T'HH:mm:ss.SSSZZ</tt>)</li>
           <li><tt>timeZone</tt> - Timezone (local timezone)</li>
+	  <li><tt>unixTimestamp</tt> - Output value will be written as a unix timestmap in ms</li>
         </ul>
       </td>
     </tr>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>net.logstash.logback</groupId>
     <artifactId>logstash-logback-encoder</artifactId>
-    <version>5.1-SNAPSHOT</version>
+    <version>5.2-SNAPSHOT</version>
 
     <name>Logstash Logback Encoder</name>
     <description>Logback encoder which will output events as Logstash-compatible JSON</description>

--- a/src/main/java/net/logstash/logback/LogstashAccessFormatter.java
+++ b/src/main/java/net/logstash/logback/LogstashAccessFormatter.java
@@ -219,6 +219,13 @@ public class LogstashAccessFormatter extends AccessEventCompositeJsonFormatter {
     public void setVersion(String version) {
         this.versionProvider.setVersion(version);
     }
+    
+    public void setUnixTimestamp(boolean enabled) {
+        this.timestampProvider.setUnixTimestamp(enabled);
+    }
+    public boolean isUnixTimestamp() {
+        return this.timestampProvider.isUnixTimestamp();
+    }
 
     
     /**

--- a/src/main/java/net/logstash/logback/LogstashFormatter.java
+++ b/src/main/java/net/logstash/logback/LogstashFormatter.java
@@ -421,6 +421,12 @@ public class LogstashFormatter extends LoggingEventCompositeJsonFormatter {
     public void setTimestampPattern(String pattern) {
         timestampProvider.setPattern(pattern);
     }
+    public void setUnixTimestamp(boolean enabled) {
+        timestampProvider.setUnixTimestamp(enabled);
+    }
+    public boolean isUnixTimestamp() {
+        return timestampProvider.isUnixTimestamp();
+    }
     
     @Override
     public void setProviders(JsonProviders<ILoggingEvent> jsonProviders) {

--- a/src/main/java/net/logstash/logback/composite/FormattedTimestampJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/FormattedTimestampJsonProvider.java
@@ -39,6 +39,8 @@ public abstract class FormattedTimestampJsonProvider<Event extends DeferredProce
 
     private FastDateFormat formatter;
     
+    private boolean unixTimestamp;
+    
     public FormattedTimestampJsonProvider() {
         setFieldName(FIELD_TIMESTAMP);
     }
@@ -54,6 +56,9 @@ public abstract class FormattedTimestampJsonProvider<Event extends DeferredProce
     }
 
     protected String getFormattedTimestamp(Event event) {
+        if (unixTimestamp) {
+            return String.valueOf(getTimestampAsMillis(event));
+        }
         return formatter.format(getTimestampAsMillis(event));
     }
 
@@ -61,7 +66,9 @@ public abstract class FormattedTimestampJsonProvider<Event extends DeferredProce
     
     @Override
     public void start() {
-        formatter = FastDateFormat.getInstance(pattern, timeZone);
+        if ( ! unixTimestamp ) {
+            formatter = FastDateFormat.getInstance(pattern, timeZone);
+        }
         super.start();
     }
     
@@ -77,4 +84,11 @@ public abstract class FormattedTimestampJsonProvider<Event extends DeferredProce
     public void setTimeZone(String timeZoneId) {
         this.timeZone = TimeZone.getTimeZone(timeZoneId);
     }
+    public boolean isUnixTimestamp() {
+        return unixTimestamp;
+    }
+    public void setUnixTimestamp(boolean unixTimestamp) {
+        this.unixTimestamp = unixTimestamp;
+    }
+ 
 }

--- a/src/main/java/net/logstash/logback/encoder/LogstashAccessEncoder.java
+++ b/src/main/java/net/logstash/logback/encoder/LogstashAccessEncoder.java
@@ -99,6 +99,13 @@ public class LogstashAccessEncoder extends AccessEventCompositeJsonEncoder {
     public void setVersion(String version) {
         getFormatter().setVersion(version);
     }
+    
+    public boolean isUnixTimestamp() {
+        return getFormatter().isUnixTimestamp();
+    }
+    public void setUnixTimestamp(boolean enabled) {
+        getFormatter().setUnixTimestamp(enabled);
+    }
 
     
     /**

--- a/src/main/java/net/logstash/logback/encoder/LogstashEncoder.java
+++ b/src/main/java/net/logstash/logback/encoder/LogstashEncoder.java
@@ -212,13 +212,23 @@ public class LogstashEncoder extends LoggingEventCompositeJsonEncoder {
     public String getTimestampPattern() {
         return getFormatter().getTimestampPattern();
     }
+    
     public void setTimestampPattern(String pattern) {
         getFormatter().setTimestampPattern(pattern);
     }
-
+    
+    public boolean isUnixTimestamp() {
+        return getFormatter().isUnixTimestamp();
+    }
+    
+    public void setUnixTimestamp(boolean enabled) {
+        getFormatter().setUnixTimestamp(enabled);
+    }
+    
     public String getVersion() {
         return getFormatter().getVersion();
     }
+    
     public void setVersion(String version) {
         getFormatter().setVersion(version);
     }

--- a/src/test/java/net/logstash/logback/encoder/LogstashAccessEncoderTest.java
+++ b/src/test/java/net/logstash/logback/encoder/LogstashAccessEncoderTest.java
@@ -150,6 +150,21 @@ public class LogstashAccessEncoderTest {
     }
     
     @Test
+    public void unixTimestamp() throws Exception {
+        long timestamp = System.currentTimeMillis();
+        IAccessEvent event = mockBasicILoggingEvent();
+        when(event.getTimeStamp()).thenReturn(timestamp);
+        
+        encoder.setUnixTimestamp(true);
+        encoder.start();
+        byte[] encoded = encoder.encode(event);
+        
+        JsonNode node = MAPPER.readTree(encoded);
+        
+        assertThat(node.get("@timestamp").textValue()).isEqualTo(String.valueOf(timestamp));
+    }
+    
+    @Test
     public void requestAndResponseHeadersAreIncluded() throws Exception {
 
         IAccessEvent event = mockBasicILoggingEvent();

--- a/src/test/java/net/logstash/logback/encoder/LogstashEncoderTest.java
+++ b/src/test/java/net/logstash/logback/encoder/LogstashEncoderTest.java
@@ -609,6 +609,28 @@ public class LogstashEncoderTest {
         assertThat(node.get("level_value").intValue()).isEqualTo(40000);
     }
     
+    @Test
+    public void unixTimestamp() throws Exception {
+        final long timestamp = System.currentTimeMillis();
+        
+        ILoggingEvent event = mockBasicILoggingEvent(Level.ERROR);
+        when(event.getTimeStamp()).thenReturn(timestamp);
+        
+        encoder.setUnixTimestamp( true );
+        encoder.start();
+        byte[] encoded = encoder.encode(event);
+        
+        JsonNode node = MAPPER.readTree(encoded);
+        
+        assertThat(node.get("@timestamp").textValue()).isEqualTo(String.valueOf(timestamp));
+        assertThat(node.get("@version").textValue()).isEqualTo("1");
+        assertThat(node.get("logger_name").textValue()).isEqualTo("LoggerName");
+        assertThat(node.get("thread_name").textValue()).isEqualTo("ThreadName");
+        assertThat(node.get("message").textValue()).isEqualTo("My message");
+        assertThat(node.get("level").textValue()).isEqualTo("ERROR");
+        assertThat(node.get("level_value").intValue()).isEqualTo(40000);
+    }
+    
     public JsonNode parse(String string) throws JsonParseException, IOException {
         return FACTORY.createParser(string).readValueAsTree();
     }


### PR DESCRIPTION
In our projects, we need to generate `@timestamp` as a unix timestamp but is not quite easy to do that with current implementation.  I suggest adding a new configuration property for `LogstashEncoder` and `LogstashAccessEncoder`

Example

```xml
<encoder class="net.logstash.logback.encoder.LogstashEncoder">
  <unixTimestamp>true</unixTimestamp>
</encoder>
```