### PR TITLE
Fix #288: move logback-core to provided scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,8 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
             <version>${ch.qos.logback.version}</version>
+            <!-- required at compile time and provided at runtime -->
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
Rather simple change that moves `logback-core` to `provided` scope. Given `logstash-logback-encoder` is used from within logback itself.