### PR TITLE
Add sequence number provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1183,7 +1183,7 @@ For example:
 
 ## Customizing JSON Factory and Generator
 
-The `JsonFactory` and `JsonGenerator` used to serialize output can be customized by 
+The `JsonFactory` and `JsonGenerator` used to serialize output can be customized by
 instances of [`JsonFactoryDecorator`](/src/main/java/net/logstash/logback/decorate/JsonFactoryDecorator.java)
 or [`JsonGeneratorDecorator`](/src/main/java/net/logstash/logback/decorate/JsonGeneratorDecorator.java), respectively.
 
@@ -1614,6 +1614,17 @@ For LoggingEvents, the available providers and their configuration properties (d
           </ul></li>
           <li><tt>ethernet</tt> - Only for 'time' strategy. When defined - MAC address to use for location part of UUID. Set it to <tt>interface</tt> value to use real underlying network interface or to specific values like <tt>00:C0:F0:3D:5B:7C</tt></li>          
         </ul>
+      </td>
+    </tr>
+    <tr>
+      <td><tt>sequence</tt></td>
+      <td>
+        <p>
+          Outputs an incrementing sequence number for every log event.
+          Useful for tracking pottential message loss during transport (eg. UDP)
+        </p>
+        <ul>
+          <li><tt>fieldName</tt> - Output field name (<tt>sequence</tt>)</li></ul>
       </td>
     </tr>
   </tbody>

--- a/src/main/java/net/logstash/logback/composite/loggingevent/LoggingEventJsonProviders.java
+++ b/src/main/java/net/logstash/logback/composite/loggingevent/LoggingEventJsonProviders.java
@@ -109,5 +109,6 @@ public class LoggingEventJsonProviders extends JsonProviders<ILoggingEvent> {
     public void addThrowableRootCauseClassName(ThrowableRootCauseClassNameJsonProvider provider) {
         addProvider(provider);
     }
+    public void addSequence(SequenceJsonProvider provider) { addProvider(provider); }
 
 }

--- a/src/main/java/net/logstash/logback/composite/loggingevent/SequenceJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/loggingevent/SequenceJsonProvider.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.logstash.logback.composite.loggingevent;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import com.fasterxml.jackson.core.JsonGenerator;
+import net.logstash.logback.composite.AbstractFieldJsonProvider;
+import net.logstash.logback.composite.JsonWritingUtils;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Outputs an incrementing sequence number.
+ * Useful for determining if log events get lost along the transport chain.
+ */
+public class SequenceJsonProvider extends AbstractFieldJsonProvider<ILoggingEvent> {
+
+    public static final String FIELD_SEQUENCE = "sequence";
+
+    private final AtomicLong sequenceNumber = new AtomicLong(0L);
+
+    public SequenceJsonProvider() { setFieldName(FIELD_SEQUENCE);}
+
+    @Override
+    public void writeTo(JsonGenerator generator, ILoggingEvent iLoggingEvent) throws IOException {
+        JsonWritingUtils.writeNumberField(generator, getFieldName(), sequenceNumber.incrementAndGet());
+    }
+
+}

--- a/src/main/java/net/logstash/logback/composite/loggingevent/SequenceProvider.java
+++ b/src/main/java/net/logstash/logback/composite/loggingevent/SequenceProvider.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.logstash.logback.composite.loggingevent;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import com.fasterxml.jackson.core.JsonGenerator;
+import net.logstash.logback.composite.AbstractFieldJsonProvider;
+import net.logstash.logback.composite.JsonWritingUtils;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Outputs an incrementing sequence number.
+ * Useful for determining if log events get lost along the transport chain.
+ */
+public class SequenceProvider extends AbstractFieldJsonProvider<ILoggingEvent> {
+
+    public static final String FIELD_SEQUENCE = "sequence";
+
+    private static AtomicLong sequenceNumber = new AtomicLong(0L);
+
+    public SequenceProvider() { setFieldName(FIELD_SEQUENCE);}
+
+    @Override
+    public void writeTo(JsonGenerator generator, ILoggingEvent iLoggingEvent) throws IOException {
+        JsonWritingUtils.writeStringField(generator, getFieldName(), String.valueOf(sequenceNumber.incrementAndGet()));
+    }
+
+    void resetSequenceNumber() {
+        sequenceNumber.set(0L);
+    }
+}

--- a/src/main/java/net/logstash/logback/fieldnames/LogstashFieldNames.java
+++ b/src/main/java/net/logstash/logback/fieldnames/LogstashFieldNames.java
@@ -17,6 +17,7 @@ import net.logstash.logback.composite.loggingevent.CallerDataJsonProvider;
 import net.logstash.logback.composite.loggingevent.LogLevelJsonProvider;
 import net.logstash.logback.composite.loggingevent.LogLevelValueJsonProvider;
 import net.logstash.logback.composite.loggingevent.LoggerNameJsonProvider;
+import net.logstash.logback.composite.loggingevent.SequenceJsonProvider;
 import net.logstash.logback.composite.loggingevent.StackTraceJsonProvider;
 import net.logstash.logback.composite.loggingevent.TagsJsonProvider;
 import net.logstash.logback.composite.loggingevent.ThreadNameJsonProvider;
@@ -42,7 +43,8 @@ public class LogstashFieldNames extends LogstashCommonFieldNames {
     private String context;
     private String arguments;
     private String uuid = UuidProvider.FIELD_UUID;
-    
+    private String sequence = SequenceJsonProvider.FIELD_SEQUENCE;
+
     public String getLogger() {
         return logger;
     }
@@ -189,4 +191,8 @@ public class LogstashFieldNames extends LogstashCommonFieldNames {
     public void setUuid(String uuid) {
         this.uuid = uuid;
     }
+
+    public String getSequence() { return sequence; }
+
+    public void setSequence(String sequence) { this.sequence = sequence; }
 }

--- a/src/test/java/net/logstash/logback/ConfigurationTest.java
+++ b/src/test/java/net/logstash/logback/ConfigurationTest.java
@@ -39,6 +39,7 @@ import net.logstash.logback.composite.loggingevent.LogstashMarkersJsonProvider;
 import net.logstash.logback.composite.loggingevent.MdcJsonProvider;
 import net.logstash.logback.composite.loggingevent.MessageJsonProvider;
 import net.logstash.logback.composite.loggingevent.RawMessageJsonProvider;
+import net.logstash.logback.composite.loggingevent.SequenceJsonProvider;
 import net.logstash.logback.composite.loggingevent.StackTraceJsonProvider;
 import net.logstash.logback.composite.loggingevent.TagsJsonProvider;
 import net.logstash.logback.composite.loggingevent.ThreadNameJsonProvider;
@@ -51,7 +52,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.powermock.reflect.Whitebox;
-import org.powermock.reflect.internal.WhiteboxImpl;
 import org.slf4j.LoggerFactory;
 
 import ch.qos.logback.classic.Logger;
@@ -82,7 +82,7 @@ public class ConfigurationTest {
     public void testLogstashEncoderAppender() throws IOException {
         LoggingEventCompositeJsonEncoder encoder = getEncoder("logstashEncoderAppender");
         List<JsonProvider<ILoggingEvent>> providers = encoder.getProviders().getProviders();
-        Assert.assertEquals(20, providers.size());
+        Assert.assertEquals(21, providers.size());
 
         verifyCommonProviders(providers);
 
@@ -93,7 +93,7 @@ public class ConfigurationTest {
     public void testLoggingEventCompositeJsonEncoderAppender() throws IOException {
         LoggingEventCompositeJsonEncoder encoder = getEncoder("loggingEventCompositeJsonEncoderAppender");
         List<JsonProvider<ILoggingEvent>> providers = encoder.getProviders().getProviders();
-        Assert.assertEquals(24, providers.size());
+        Assert.assertEquals(25, providers.size());
 
         verifyCommonProviders(providers);
 
@@ -196,6 +196,10 @@ public class ConfigurationTest {
         Assert.assertEquals("id", uuidProvider.getFieldName());
         Assert.assertEquals("00:C0:F0:3D:5B:7C", uuidProvider.getEthernet());
         Assert.assertEquals(UuidProvider.STRATEGY_TIME, uuidProvider.getStrategy());
+
+        SequenceJsonProvider sequenceJsonProvider = getInstance(providers, SequenceJsonProvider.class);
+        Assert.assertNotNull(sequenceJsonProvider);
+        Assert.assertEquals("sequenceNumberField", sequenceJsonProvider.getFieldName());
     }
 
     private <T extends JsonProvider<ILoggingEvent>> T getInstance(List<JsonProvider<ILoggingEvent>> providers, Class<T> clazz) {
@@ -241,6 +245,11 @@ public class ConfigurationTest {
         Assert.assertEquals("v1", output.get("k1"));
         Assert.assertEquals("v2", output.get("k2"));
         Assert.assertEquals("v3", output.get("k3"));
+
+        Number sequence = (Number)output.get("sequenceNumberField");
+        Assert.assertNotNull(sequence);
+        Assert.assertNotEquals("", sequence);
+        Assert.assertTrue(0L < sequence.longValue());
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/net/logstash/logback/composite/loggingevent/SequenceJsonProviderTest.java
+++ b/src/test/java/net/logstash/logback/composite/loggingevent/SequenceJsonProviderTest.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.logstash.logback.composite.loggingevent;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import com.fasterxml.jackson.core.JsonGenerator;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.ArgumentMatchers.eq;
+
+public class SequenceJsonProviderTest {
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
+    private SequenceJsonProvider provider = new SequenceJsonProvider();
+
+    @Mock
+    private JsonGenerator generator;
+
+    @Mock
+    private ILoggingEvent event;
+
+    @Test
+    public void testDefaultName() throws IOException {
+        provider.writeTo(generator, event);
+
+        verify(generator).writeNumberField(eq(SequenceJsonProvider.FIELD_SEQUENCE),1);
+
+    }
+
+    @Test
+    public void testFieldName() throws IOException {
+        provider.setFieldName("newFieldName");
+
+        provider.writeTo(generator, event);
+
+        verify(generator).writeNumberField(eq("newFieldName"), 1);
+    }
+}

--- a/src/test/java/net/logstash/logback/composite/loggingevent/SequenceProviderTest.java
+++ b/src/test/java/net/logstash/logback/composite/loggingevent/SequenceProviderTest.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.logstash.logback.composite.loggingevent;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import com.fasterxml.jackson.core.JsonGenerator;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.ArgumentMatchers.eq;
+
+public class SequenceProviderTest {
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
+    private SequenceProvider provider = new SequenceProvider();
+
+    @Mock
+    private JsonGenerator generator;
+
+    @Mock
+    private ILoggingEvent event;
+
+    @Before
+    public void resetSequenceNumber() {
+        provider.resetSequenceNumber();
+    }
+
+    @Test
+    public void testDefaultName() throws IOException {
+        provider.writeTo(generator, event);
+
+        verify(generator).writeStringField(eq(SequenceProvider.FIELD_SEQUENCE), eq("1"));
+    }
+
+    @Test
+    public void testFieldName() throws IOException {
+        provider.setFieldName("newFieldName");
+
+        provider.writeTo(generator, event);
+
+        verify(generator).writeStringField(eq("newFieldName"), eq("1"));
+    }
+}

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -71,6 +71,9 @@
                     </provider>
                 </providers>
             </provider>
+            <provider class="net.logstash.logback.composite.loggingevent.SequenceJsonProvider">
+                <fieldName>sequenceNumberField</fieldName>
+            </provider>
             <provider class="net.logstash.logback.composite.loggingevent.ArgumentsJsonProvider">
                 <includeNonStructuredArguments>true</includeNonStructuredArguments>
                 <nonStructuredArgumentsFieldPrefix>prefix</nonStructuredArgumentsFieldPrefix>
@@ -99,6 +102,9 @@
                     </rawMessage>
                     </providers>
                 </nestedField>
+                <sequence>
+                    <fieldName>sequenceNumberField</fieldName>
+                </sequence>
                 <loggerName>
                     <shortenedLoggerNameLength>20</shortenedLoggerNameLength>
                 </loggerName>


### PR DESCRIPTION
When configured, this provider outputs an incrementing sequence number for every log event.
This can be useful to detect gaps in your log stream and help identify problems with your log transport.
It also makes reading logs easier as it helps the reader to distinguish between missing log lines and flaky system behavior. 