### PR TITLE
Don't fill in stack trace in test exception

### DIFF
--- a/src/test/java/net/logstash/logback/argument/StructuredArgumentsToStringTest.java
+++ b/src/test/java/net/logstash/logback/argument/StructuredArgumentsToStringTest.java
@@ -29,7 +29,12 @@ public class StructuredArgumentsToStringTest {
     private static  class BuguyToString {
         @Override
         public String toString() {
-            throw new NullPointerException("npe");
+            throw new NullPointerException("npe") {
+                @Override
+                public synchronized Throwable fillInStackTrace() {
+                    return this;
+                }
+            };
         }
     }
 


### PR DESCRIPTION
When configured, this provider outputs an incrementing sequence number for every log event.
This can be useful to detect gaps in your log stream and help identify problems with your log transport.
It also makes reading logs easier as it helps the reader to distinguish between missing log lines and flaky system behavior. 
 