### PR TITLE
Add support for excluding markers via <includeTags>false</includeTags>

### DIFF
--- a/README.md
+++ b/README.md
@@ -762,7 +762,8 @@ The field names can be customized (see [Customizing Standard Field Names](#custo
 | `level`       | String name of the level of the event
 | `level_value` | Integer value of the level of the event
 | `stack_trace` | (Only if a throwable was logged) The stacktrace of the throwable.  Stackframes are separated by line endings.
-| `tags`        | (Only if tags are found) The names of any markers not explicitly handled.  (e.g. markers from `MarkerFactory.getMarker` will be included as tags, but the markers from [`Markers`](/src/main/java/net/logstash/logback/marker/Markers.java) will not.)
+| `tags`        | (Only if tags are found) The names of any markers not explicitly handled.  (e.g. markers from `MarkerFactory.getMarker` will be included as tags, but the markers from [`Markers`](/src/main/java/net/logstash/logback/marker/Markers.java) will not.) This can be fully disabled by specifying `<includeTags>false</includeTags>`, in the encoder/layout/appender configuration.
+
 
 
 ### MDC fields

--- a/src/main/java/net/logstash/logback/LogstashFormatter.java
+++ b/src/main/java/net/logstash/logback/LogstashFormatter.java
@@ -105,7 +105,11 @@ public class LogstashFormatter extends LoggingEventCompositeJsonFormatter {
     @Deprecated
     private ContextMapJsonProvider contextMapProvider;
     private GlobalCustomFieldsJsonProvider<ILoggingEvent> globalCustomFieldsProvider;
-    private final TagsJsonProvider tagsProvider = new TagsJsonProvider();
+    /**
+     * When not null, markers will be included according
+     * to the logic in {@link TagsJsonProvider}
+     */
+    private TagsJsonProvider tagsProvider = new TagsJsonProvider();
     private final LogstashMarkersJsonProvider logstashMarkersProvider = new LogstashMarkersJsonProvider();
     private ArgumentsJsonProvider argumentsProvider = new ArgumentsJsonProvider();
     
@@ -250,7 +254,23 @@ public class LogstashFormatter extends LoggingEventCompositeJsonFormatter {
             }
         }
     }
-    
+
+    public boolean isIncludeTags() {
+        return this.tagsProvider != null;
+    }
+
+    public void setIncludeTags(boolean includeTags) {
+        if (isIncludeTags() != includeTags) {
+            if (includeTags) {
+                tagsProvider = new TagsJsonProvider();
+                addProvider(tagsProvider);
+            } else {
+                getProviders().removeProvider(tagsProvider);
+                tagsProvider = null;
+            }
+        }
+    }
+
     public boolean isIncludeStructuredArguments() {
         return this.argumentsProvider.isIncludeStructuredArguments();
     }

--- a/src/main/java/net/logstash/logback/encoder/LogstashEncoder.java
+++ b/src/main/java/net/logstash/logback/encoder/LogstashEncoder.java
@@ -120,6 +120,14 @@ public class LogstashEncoder extends LoggingEventCompositeJsonEncoder {
         getFormatter().setExcludeMdcKeyNames(excludeMdcKeyNames);
     }
 
+    public boolean isIncludeTags() {
+        return getFormatter().isIncludeTags();
+    }
+
+    public void setIncludeTags(boolean includeTags) {
+        getFormatter().setIncludeTags(includeTags);
+    }
+
     public boolean isIncludeContext() {
         return getFormatter().isIncludeContext();
     }

--- a/src/main/java/net/logstash/logback/layout/LogstashLayout.java
+++ b/src/main/java/net/logstash/logback/layout/LogstashLayout.java
@@ -109,7 +109,15 @@ public class LogstashLayout extends LoggingEventCompositeJsonLayout {
     public void setExcludeMdcKeyNames(List<String> excludeMdcKeyNames) {
         getFormatter().setExcludeMdcKeyNames(excludeMdcKeyNames);
     }
-    
+
+    public boolean isIncludeTags() {
+        return getFormatter().isIncludeTags();
+    }
+
+    public void setIncludeTags(boolean includeTags) {
+        getFormatter().setIncludeTags(includeTags);
+    }
+
     public boolean isIncludeContext() {
         return getFormatter().isIncludeContext();
     }

--- a/src/test/java/net/logstash/logback/encoder/LogstashEncoderTest.java
+++ b/src/test/java/net/logstash/logback/encoder/LogstashEncoderTest.java
@@ -528,7 +528,23 @@ public class LogstashEncoderTest {
         
         assertThat(node.findValue("tags")).isNull();
     }
-    
+
+    @Test
+    public void markerNoneIncluded() throws Exception {
+        Marker marker = MarkerFactory.getMarker("bees");
+        marker.add(MarkerFactory.getMarker("knees"));
+        ILoggingEvent event = mockBasicILoggingEvent(Level.INFO);
+        when(event.getMarker()).thenReturn(marker);
+
+        encoder.setIncludeTags(false);
+        encoder.start();
+        byte[] encoded = encoder.encode(event);
+
+        JsonNode node = MAPPER.readTree(encoded);
+
+        assertThat(node.findValue("tags")).isNull();
+    }
+
     /**
      * Tests the old way of appending a json_message to the event.
      * 

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -16,6 +16,7 @@
                 <version>[ignore]</version>
             </fieldNames>
             <includeMdc>false</includeMdc>
+            <includeTags>false</includeTags>
         </encoder>
     </appender>
     


### PR DESCRIPTION
This behavior mimics the includeMdc behavior and causes
the tags serialization to be skipped.