### PR TITLE
Trigger SSL handshake as soon as the socket is connected (#327)

### DIFF
--- a/src/main/java/net/logstash/logback/appender/AbstractLogstashTcpSocketAppender.java
+++ b/src/main/java/net/logstash/logback/appender/AbstractLogstashTcpSocketAppender.java
@@ -562,6 +562,13 @@ public abstract class AbstractLogstashTcpSocketAppender<Event extends DeferredPr
                     tempSocket.connect(new InetSocketAddress(getHostString(currentDestination), currentDestination.getPort()), acceptConnectionTimeout);
                     
                     /*
+                     * Trigger SSL handshake immediately and declare the socket unconnected if it fails
+                     */
+                    if (tempSocket instanceof SSLSocket) {
+                    	((SSLSocket)tempSocket).startHandshake();
+                    }
+                    
+                    /*
                      * Issue #218, make buffering the output stream optional.
                      */
                     tempOutputStream = writeBufferSize > 0


### PR DESCRIPTION
When SSL is enabled, we should trigger the SSL handshake as soon as the socket is connected.
This way if the handshake fails the socket is declared unconnected.

(Fix for #327)
