### PR TITLE
Update Jackson to 2.9.9.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
         <!-- runtime dependencies -->
         <ch.qos.logback.version>1.2.3</ch.qos.logback.version>
-        <com.fasterxml.jackson.version>2.9.9.3</com.fasterxml.jackson.version>
+        <com.fasterxml.jackson.version>2.9.9.20190807</com.fasterxml.jackson.version>
         <com.fasterxml.uuid.version>3.2.0</com.fasterxml.uuid.version>
 
         <!-- shaded runtime dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
         <!-- runtime dependencies -->
         <ch.qos.logback.version>1.2.3</ch.qos.logback.version>
-        <com.fasterxml.jackson.version>2.9.9</com.fasterxml.jackson.version>
+        <com.fasterxml.jackson.version>2.9.9.3</com.fasterxml.jackson.version>
         <com.fasterxml.uuid.version>3.2.0</com.fasterxml.uuid.version>
 
         <!-- shaded runtime dependencies -->


### PR DESCRIPTION
Jackson 2.9.9 contains a few vulnerabilities reported by Snyk:

```
✗ High severity vulnerability found in com.fasterxml.jackson.core:jackson-databind
  Description: Deserialization of Untrusted Data
  Info: https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-450207
  Introduced through: net.logstash.logback:logstash-logback-encoder@6.1
  From: net.logstash.logback:logstash-logback-encoder@6.1 > com.fasterxml.jackson.core:jackson-databind@2.9.9

✗ High severity vulnerability found in com.fasterxml.jackson.core:jackson-databind
  Description: Deserialization of Untrusted Data
  Info: https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-450917
  Introduced through: net.logstash.logback:logstash-logback-encoder@6.1
  From: net.logstash.logback:logstash-logback-encoder@6.1 > com.fasterxml.jackson.core:jackson-databind@2.9.9

✗ High severity vulnerability found in com.fasterxml.jackson.core:jackson-databind
  Description: Deserialization of Untrusted Data
  Info: https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-455617
  Introduced through: net.logstash.logback:logstash-logback-encoder@6.1
  From: net.logstash.logback:logstash-logback-encoder@6.1 > com.fasterxml.jackson.core:jackson-databind@2.9.9
```