### PR TITLE
Correct typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2282,7 +2282,7 @@ or a `LogstashEncoder` like this:
 </encoder>
 ```
 
-You can do something similar for `AccessEventCompositeJsonEncoder` and `LogstashAccessEnceder` as well, if your `JsonProvider` handles `IAccessEvent`s.
+You can do something similar for `AccessEventCompositeJsonEncoder` and `LogstashAccessEncoder` as well, if your `JsonProvider` handles `IAccessEvent`s.
 
 ## Status Listeners
 


### PR DESCRIPTION
Changed `LogstashAccessEnceder` to `LogstashAccessEncoder`