### PR TITLE
Check that event has caller data

### DIFF
--- a/src/main/java/net/logstash/logback/composite/loggingevent/CallerDataJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/loggingevent/CallerDataJsonProvider.java
@@ -59,6 +59,9 @@ public class CallerDataJsonProvider extends AbstractFieldJsonProvider<ILoggingEv
         event.getCallerData();
     }
     private StackTraceElement extractCallerData(final ILoggingEvent event) {
+        if (!event.hasCallerData()) {
+            return null;
+        }
         final StackTraceElement[] ste = event.getCallerData();
         if (ste == null || ste.length == 0) {
             return null;


### PR DESCRIPTION
From 'getCallerData()' documentation "Note that calling this event may trigger the computation of caller data." To avoid computation can verify that event has CallerData