### PR TITLE
Added isIncludeContext check to access logger encoder.

### DIFF
--- a/src/main/java/net/logstash/logback/LogstashAccessFormatter.java
+++ b/src/main/java/net/logstash/logback/LogstashAccessFormatter.java
@@ -13,6 +13,7 @@
  */
 package net.logstash.logback;
 
+import ch.qos.logback.classic.spi.ILoggingEvent;
 import net.logstash.logback.composite.ContextJsonProvider;
 import net.logstash.logback.composite.FieldNamesAware;
 import net.logstash.logback.composite.GlobalCustomFieldsJsonProvider;
@@ -46,24 +47,24 @@ import com.fasterxml.jackson.databind.JsonNode;
 /**
  * A {@link AccessEventCompositeJsonFormatter} that contains a common
  * pre-defined set of {@link JsonProvider}s.
- * 
+ *
  * The included providers are configured via properties on this
  * formatter, rather than configuring the providers directly.
- * This leads to a somewhat simpler configuration definitions. 
- * 
+ * This leads to a somewhat simpler configuration definitions.
+ *
  * You cannot remove any of the pre-defined providers, but
  * you can add additional providers via {@link #addProvider(JsonProvider)}.
- * 
+ *
  * If you would like full control over the providers, you
  * should instead use {@link AccessEventCompositeJsonFormatter} directly.
  */
 public class LogstashAccessFormatter extends AccessEventCompositeJsonFormatter {
-    
+
     /**
      * The field names to use when writing the access event fields
      */
     protected LogstashAccessFieldNames fieldNames = new LogstashAccessFieldNames();
-    
+
     private final AccessEventFormattedTimestampJsonProvider timestampProvider = new AccessEventFormattedTimestampJsonProvider();
     private final LogstashVersionJsonProvider<IAccessEvent> versionProvider = new LogstashVersionJsonProvider<IAccessEvent>();
     private final AccessMessageJsonProvider messageProvider = new AccessMessageJsonProvider();
@@ -78,12 +79,12 @@ public class LogstashAccessFormatter extends AccessEventCompositeJsonFormatter {
     private final ElapsedTimeJsonProvider elapsedTimeProvider = new ElapsedTimeJsonProvider();
     private final RequestHeadersJsonProvider requestHeadersProvider = new RequestHeadersJsonProvider();
     private final ResponseHeadersJsonProvider responseHeadersProvider = new ResponseHeadersJsonProvider();
-    private final ContextJsonProvider<IAccessEvent> contextProvider = new ContextJsonProvider<IAccessEvent>();
+    private ContextJsonProvider<IAccessEvent> contextProvider = new ContextJsonProvider<IAccessEvent>();
     private GlobalCustomFieldsJsonProvider<IAccessEvent> globalCustomFieldsProvider;
-    
+
     public LogstashAccessFormatter(ContextAware declaredOrigin) {
         super(declaredOrigin);
-        
+
         getProviders().addTimestamp(this.timestampProvider);
         getProviders().addVersion(this.versionProvider);
         getProviders().addAccessMessage(this.messageProvider);
@@ -100,7 +101,7 @@ public class LogstashAccessFormatter extends AccessEventCompositeJsonFormatter {
         getProviders().addResponseHeaders(this.responseHeadersProvider);
         getProviders().addContext(this.contextProvider);
     }
-    
+
     @Override
     public void start() {
         configureProviderFieldNames();
@@ -119,12 +120,12 @@ public class LogstashAccessFormatter extends AccessEventCompositeJsonFormatter {
     public void addProvider(JsonProvider<IAccessEvent> provider) {
         getProviders().addProvider(provider);
     }
-    
+
     @Override
     public AccessEventJsonProviders getProviders() {
         return (AccessEventJsonProviders) super.getProviders();
     }
-    
+
     public LogstashAccessFieldNames getFieldNames() {
         return fieldNames;
     }
@@ -139,7 +140,7 @@ public class LogstashAccessFormatter extends AccessEventCompositeJsonFormatter {
     public void setTimeZone(String timeZoneId) {
         this.timestampProvider.setTimeZone(timeZoneId);
         this.messageProvider.setTimeZone(timeZoneId);
-    }    
+    }
     public String getTimestampPattern() {
         return timestampProvider.getPattern();
     }
@@ -152,7 +153,7 @@ public class LogstashAccessFormatter extends AccessEventCompositeJsonFormatter {
                 ? null
                 : globalCustomFieldsProvider.getCustomFields();
     }
-    
+
     public void setCustomFieldsFromString(String customFields) {
         if (customFields == null || customFields.length() == 0) {
             getProviders().removeProvider(globalCustomFieldsProvider);
@@ -164,7 +165,7 @@ public class LogstashAccessFormatter extends AccessEventCompositeJsonFormatter {
             globalCustomFieldsProvider.setCustomFields(customFields);
         }
     }
-    
+
     public void setCustomFields(JsonNode customFields) {
         if (customFields == null) {
             getProviders().removeProvider(globalCustomFieldsProvider);
@@ -176,13 +177,13 @@ public class LogstashAccessFormatter extends AccessEventCompositeJsonFormatter {
             globalCustomFieldsProvider.setCustomFieldsNode(customFields);
         }
     }
-    
+
     public JsonNode getCustomFields() {
         return globalCustomFieldsProvider == null
                 ? null
                 : globalCustomFieldsProvider.getCustomFieldsNode();
     }
-    
+
     public boolean getLowerCaseHeaderNames() {
         return this.requestHeadersProvider.getLowerCaseHeaderNames();
     }
@@ -195,25 +196,41 @@ public class LogstashAccessFormatter extends AccessEventCompositeJsonFormatter {
         this.requestHeadersProvider.setLowerCaseHeaderNames(lowerCaseHeaderNames);
         this.responseHeadersProvider.setLowerCaseHeaderNames(lowerCaseHeaderNames);
     }
-    
+
     public HeaderFilter getRequestHeaderFilter() {
         return this.requestHeadersProvider.getFilter();
     }
-    
+
     @DefaultClass(IncludeExcludeHeaderFilter.class)
     public void setRequestHeaderFilter(HeaderFilter filter) {
         this.requestHeadersProvider.setFilter(filter);
     }
-    
+
     public HeaderFilter getResponseHeaderFilter() {
         return this.responseHeadersProvider.getFilter();
     }
-    
+
     @DefaultClass(IncludeExcludeHeaderFilter.class)
     public void setResponseHeaderFilter(HeaderFilter filter) {
         this.responseHeadersProvider.setFilter(filter);
     }
-    
+
+    public boolean isIncludeContext() {
+        return contextProvider != null;
+    }
+
+    public void setIncludeContext(boolean includeContext) {
+        if (isIncludeContext() != includeContext) {
+            getProviders().removeProvider(contextProvider);
+            if (includeContext) {
+                contextProvider = new ContextJsonProvider<IAccessEvent>();
+                getProviders().addContext(contextProvider);
+            } else {
+                contextProvider = null;
+            }
+        }
+    }
+
     public String getVersion() {
         return this.versionProvider.getVersion();
     }
@@ -221,7 +238,7 @@ public class LogstashAccessFormatter extends AccessEventCompositeJsonFormatter {
         this.versionProvider.setVersion(version);
     }
 
-    
+
     /**
      * @deprecated Use {@link #isWriteVersionAsInteger()}
      * @return true if the version should be written as a string
@@ -238,14 +255,14 @@ public class LogstashAccessFormatter extends AccessEventCompositeJsonFormatter {
     public void setWriteVersionAsString(boolean writeVersionAsString) {
         this.versionProvider.setWriteAsString(writeVersionAsString);
     }
-    
+
     public boolean isWriteVersionAsInteger() {
         return this.versionProvider.isWriteAsInteger();
     }
     public void setWriteVersionAsInteger(boolean writeVersionAsInteger) {
         this.versionProvider.setWriteAsInteger(writeVersionAsInteger);
     }
-    
+
 
     @Override
     public void setProviders(JsonProviders<IAccessEvent> jsonProviders) {

--- a/src/main/java/net/logstash/logback/encoder/LogstashAccessEncoder.java
+++ b/src/main/java/net/logstash/logback/encoder/LogstashAccessEncoder.java
@@ -23,12 +23,12 @@ import ch.qos.logback.access.spi.IAccessEvent;
 import ch.qos.logback.core.joran.spi.DefaultClass;
 
 public class LogstashAccessEncoder extends AccessEventCompositeJsonEncoder {
-    
+
     @Override
     protected CompositeJsonFormatter<IAccessEvent> createFormatter() {
         return new LogstashAccessFormatter(this);
     }
-    
+
     @Override
     protected LogstashAccessFormatter getFormatter() {
         return (LogstashAccessFormatter) super.getFormatter();
@@ -41,7 +41,7 @@ public class LogstashAccessEncoder extends AccessEventCompositeJsonEncoder {
     public LogstashAccessFieldNames getFieldNames() {
         return getFormatter().getFieldNames();
     }
-    
+
     public void setFieldNames(LogstashAccessFieldNames fieldNames) {
         getFormatter().setFieldNames(fieldNames);
     }
@@ -53,51 +53,59 @@ public class LogstashAccessEncoder extends AccessEventCompositeJsonEncoder {
     public void setTimeZone(String timeZoneId) {
         getFormatter().setTimeZone(timeZoneId);
     }
-    
+
     public String getTimestampPattern() {
         return getFormatter().getTimestampPattern();
     }
     public void setTimestampPattern(String pattern) {
         getFormatter().setTimestampPattern(pattern);
     }
-    
+
     public void setCustomFields(String customFields) {
         getFormatter().setCustomFieldsFromString(customFields);
     }
-    
+
     public String getCustomFields() {
         return getFormatter().getCustomFieldsAsString();
     }
-    
+
     public boolean getLowerCaseHeaderNames() {
         return getFormatter().getLowerCaseHeaderNames();
     }
 
     /**
-     * When true, names of headers will be written to JSON output in lowercase. 
+     * When true, names of headers will be written to JSON output in lowercase.
      */
     public void setLowerCaseHeaderNames(boolean lowerCaseHeaderNames) {
         getFormatter().setLowerCaseHeaderNames(lowerCaseHeaderNames);
     }
-    
+
     public HeaderFilter getRequestHeaderFilter() {
         return getFormatter().getRequestHeaderFilter();
     }
-    
+
     @DefaultClass(IncludeExcludeHeaderFilter.class)
     public void setRequestHeaderFilter(HeaderFilter filter) {
         getFormatter().setRequestHeaderFilter(filter);
     }
-    
+
     public HeaderFilter getResponseHeaderFilter() {
         return getFormatter().getResponseHeaderFilter();
     }
-    
+
     @DefaultClass(IncludeExcludeHeaderFilter.class)
     public void setResponseHeaderFilter(HeaderFilter filter) {
         getFormatter().setResponseHeaderFilter(filter);
     }
-    
+
+    public boolean isIncludeContext() {
+        return getFormatter().isIncludeContext();
+    }
+
+    public void setIncludeContext(boolean includeContext) {
+        getFormatter().setIncludeContext(includeContext);
+    }
+
     public String getVersion() {
         return getFormatter().getVersion();
     }
@@ -105,7 +113,6 @@ public class LogstashAccessEncoder extends AccessEventCompositeJsonEncoder {
         getFormatter().setVersion(version);
     }
 
-    
     /**
      * @deprecated Use {@link #isWriteVersionAsInteger()}
      */
@@ -120,12 +127,12 @@ public class LogstashAccessEncoder extends AccessEventCompositeJsonEncoder {
     public void setWriteVersionAsString(boolean writeVersionAsString) {
         getFormatter().setWriteVersionAsString(writeVersionAsString);
     }
-    
+
     public boolean isWriteVersionAsInteger() {
         return getFormatter().isWriteVersionAsInteger();
     }
     public void setWriteVersionAsInteger(boolean writeVersionAsInteger) {
         getFormatter().setWriteVersionAsInteger(writeVersionAsInteger);
     }
-    
+
 }

--- a/src/main/java/net/logstash/logback/layout/LogstashAccessLayout.java
+++ b/src/main/java/net/logstash/logback/layout/LogstashAccessLayout.java
@@ -23,25 +23,25 @@ import ch.qos.logback.access.spi.IAccessEvent;
 import ch.qos.logback.core.joran.spi.DefaultClass;
 
 public class LogstashAccessLayout extends AccessEventCompositeJsonLayout {
-    
+
     @Override
     protected CompositeJsonFormatter<IAccessEvent> createFormatter() {
         return new LogstashAccessFormatter(this);
     }
-    
+
     @Override
     protected LogstashAccessFormatter getFormatter() {
         return (LogstashAccessFormatter) super.getFormatter();
     }
-    
+
     public void addProvider(JsonProvider<IAccessEvent> provider) {
         getFormatter().addProvider(provider);
     }
-    
+
     public LogstashAccessFieldNames getFieldNames() {
         return getFormatter().getFieldNames();
     }
-    
+
     public void setFieldNames(LogstashAccessFieldNames fieldNames) {
         getFormatter().setFieldNames(fieldNames);
     }
@@ -64,17 +64,17 @@ public class LogstashAccessLayout extends AccessEventCompositeJsonLayout {
     public void setCustomFields(String customFields) {
         getFormatter().setCustomFieldsFromString(customFields);
     }
-    
+
     public String getCustomFields() {
         return getFormatter().getCustomFieldsAsString();
     }
-    
+
     public boolean getLowerCaseHeaderNames() {
         return getFormatter().getLowerCaseHeaderNames();
     }
 
     /**
-     * When true, names of headers will be written to JSON output in lowercase. 
+     * When true, names of headers will be written to JSON output in lowercase.
      */
     public void setLowerCaseHeaderNames(boolean lowerCaseHeaderNames) {
         getFormatter().setLowerCaseHeaderNames(lowerCaseHeaderNames);
@@ -83,19 +83,27 @@ public class LogstashAccessLayout extends AccessEventCompositeJsonLayout {
     public HeaderFilter getRequestHeaderFilter() {
         return getFormatter().getRequestHeaderFilter();
     }
-    
+
     @DefaultClass(IncludeExcludeHeaderFilter.class)
     public void setRequestHeaderFilter(HeaderFilter filter) {
         getFormatter().setRequestHeaderFilter(filter);
     }
-    
+
     public HeaderFilter getResponseHeaderFilter() {
         return getFormatter().getResponseHeaderFilter();
     }
-    
+
     @DefaultClass(IncludeExcludeHeaderFilter.class)
     public void setResponseHeaderFilter(HeaderFilter filter) {
         getFormatter().setResponseHeaderFilter(filter);
+    }
+
+    public boolean isIncludeContext() {
+        return getFormatter().isIncludeContext();
+    }
+
+    public void setIncludeContext(boolean includeContext) {
+        getFormatter().setIncludeContext(includeContext);
     }
 
     public String getVersion() {
@@ -105,7 +113,7 @@ public class LogstashAccessLayout extends AccessEventCompositeJsonLayout {
         getFormatter().setVersion(version);
     }
 
-    
+
     /**
      * @deprecated Use {@link #isWriteVersionAsInteger()}
      */
@@ -120,12 +128,12 @@ public class LogstashAccessLayout extends AccessEventCompositeJsonLayout {
     public void setWriteVersionAsString(boolean writeVersionAsString) {
         getFormatter().setWriteVersionAsString(writeVersionAsString);
     }
-    
+
     public boolean isWriteVersionAsInteger() {
         return getFormatter().isWriteVersionAsInteger();
     }
     public void setWriteVersionAsInteger(boolean writeVersionAsInteger) {
         getFormatter().setWriteVersionAsInteger(writeVersionAsInteger);
     }
-    
+
 }


### PR DESCRIPTION
This PR adds the same functionality to the access logger that is already implemented in the standard JSON logger.

If one set the element `includeContext` to `false` the context of the logger is not added to the JSON output.

```xml
<configuration>
    <!-- always a good activate OnConsoleStatusListener -->
    <statusListener class="ch.qos.logback.core.status.OnConsoleStatusListener"/>
    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
        <encoder class="net.logstash.logback.encoder.LogstashAccessEncoder">
            <timeZone>UTC</timeZone>
            <includeContext>false</includeContext>
            <fieldNames>
                <requestHeaders>request_headers</requestHeaders>
                <responseHeaders>response_headers</responseHeaders>
            </fieldNames>
        </encoder>
    </appender>
    <appender-ref ref="STDOUT"/>
</configuration>
```