### PR TITLE
Replace `Charset.forName("UTF-8")` to `StandardCharsets.UTF_8`

### DIFF
--- a/src/main/java/net/logstash/logback/appender/AbstractLogstashTcpSocketAppender.java
+++ b/src/main/java/net/logstash/logback/appender/AbstractLogstashTcpSocketAppender.java
@@ -23,6 +23,7 @@ import java.net.Socket;
 import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Formatter;
@@ -248,7 +249,7 @@ public abstract class AbstractLogstashTcpSocketAppender<Event extends DeferredPr
      * The charset to use when writing the {@link #keepAliveMessage}.
      * Defaults to UTF-8.
      */
-    private Charset keepAliveCharset = Charset.forName("UTF-8");
+    private Charset keepAliveCharset = StandardCharsets.UTF_8;
     
     /**
      * The {@link #keepAliveMessage} translated to bytes using the {@link #keepAliveCharset}.

--- a/src/main/java/net/logstash/logback/marker/LogstashBasicMarker.java
+++ b/src/main/java/net/logstash/logback/marker/LogstashBasicMarker.java
@@ -115,7 +115,7 @@ public class LogstashBasicMarker implements Marker {
         if (refereceList != null) {
             return refereceList.iterator();
         } else {
-            return Collections.EMPTY_LIST.iterator();
+            return Collections.emptyIterator();
         }
     }
 

--- a/src/test/java/net/logstash/logback/ConfigurationTest.java
+++ b/src/test/java/net/logstash/logback/ConfigurationTest.java
@@ -15,6 +15,7 @@ package net.logstash.logback;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
@@ -227,7 +228,7 @@ public class ConfigurationTest {
         byte[] encoded = encoder.encode(listAppender.list.get(0));
         
 
-        Map<String, Object> output = parseJson(new String(encoded, "UTF-8"));
+        Map<String, Object> output = parseJson(new String(encoded, StandardCharsets.UTF_8));
         Assert.assertNotNull(output.get("@timestamp"));
         Assert.assertEquals("1", output.get("@version"));
         Assert.assertEquals("message arg k1=v1 k2=[v2] v3", output.get("customMessage"));

--- a/src/test/java/net/logstash/logback/appender/LogstashTcpSocketAppenderTest.java
+++ b/src/test/java/net/logstash/logback/appender/LogstashTcpSocketAppenderTest.java
@@ -39,7 +39,7 @@ import java.net.Socket;
 import java.net.SocketAddress;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
@@ -127,7 +127,7 @@ public class LogstashTcpSocketAppenderTest {
         when(context.getStatusManager()).thenReturn(statusManager);
         when(socketFactory.createSocket()).thenReturn(socket);
         when(socket.getOutputStream()).thenReturn(outputStream);
-        when(encoder.encode(event1)).thenReturn("event1".getBytes("UTF-8"));
+        when(encoder.encode(event1)).thenReturn("event1".getBytes(StandardCharsets.UTF_8));
         appender.addListener(listener);
         
     }
@@ -217,7 +217,7 @@ public class LogstashTcpSocketAppenderTest {
         
         verify(encoder).start();
         
-        doThrow(new RuntimeException()).doReturn("event1".getBytes("UTF-8")).when(encoder).encode(event1);
+        doThrow(new RuntimeException()).doReturn("event1".getBytes(StandardCharsets.UTF_8)).when(encoder).encode(event1);
         
         appender.append(event1);
         
@@ -368,7 +368,7 @@ public class LogstashTcpSocketAppenderTest {
         // attempts will succeed. This should force the appender to close the connection
         // and attempt to reconnect
         doThrow(new RuntimeException())
-            .doReturn("event1".getBytes("UTF-8"))
+            .doReturn("event1".getBytes(StandardCharsets.UTF_8))
             .when(encoder).encode(event1);
         
         
@@ -491,11 +491,11 @@ public class LogstashTcpSocketAppenderTest {
 
         // Schedule keepalive message every 100ms
         appender.setKeepAliveMessage("UNIX");
-        appender.setKeepAliveCharset(Charset.forName("UTF-8"));
+        appender.setKeepAliveCharset(StandardCharsets.UTF_8);
         appender.setKeepAliveDuration(Duration.buildByMilliseconds(100));
 
         String expectedKeepAlives = SeparatorParser.parseSeparator("UNIX") + SeparatorParser.parseSeparator("UNIX");
-        byte[] expectedKeepAlivesBytes = expectedKeepAlives.getBytes("UTF-8");
+        byte[] expectedKeepAlivesBytes = expectedKeepAlives.getBytes(StandardCharsets.UTF_8);
 
         // Use a ByteArrayOutputStream to capture the actual keep alive message bytes
         ByteArrayOutputStream bos = new ByteArrayOutputStream();

--- a/src/test/java/net/logstash/logback/encoder/CompositeJsonEncoderTest.java
+++ b/src/test/java/net/logstash/logback/encoder/CompositeJsonEncoderTest.java
@@ -25,7 +25,7 @@ import java.io.BufferedOutputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import net.logstash.logback.Logback11Support;
 import net.logstash.logback.composite.CompositeJsonFormatter;
@@ -146,7 +146,7 @@ public class CompositeJsonEncoderTest {
         verify(formatter).setContext(context);
         verify(formatter).start();
         
-        verify(prefix).setCharset(Charset.forName("UTF-8"));
+        verify(prefix).setCharset(StandardCharsets.UTF_8);
         verify(prefix).start();
         verify(suffix).start();
         
@@ -181,8 +181,8 @@ public class CompositeJsonEncoderTest {
         LayoutWrappingEncoder<ILoggingEvent> prefix = mock(LayoutWrappingEncoder.class);
         Encoder<ILoggingEvent> suffix = mock(Encoder.class);
         
-        when(prefix.encode(event)).thenReturn("prefix".getBytes("UTF-8"));
-        when(suffix.encode(event)).thenReturn("suffix".getBytes("UTF-8"));
+        when(prefix.encode(event)).thenReturn("prefix".getBytes(StandardCharsets.UTF_8));
+        when(suffix.encode(event)).thenReturn("suffix".getBytes(StandardCharsets.UTF_8));
         
         encoder.setPrefix(prefix);
         encoder.setSuffix(suffix);
@@ -194,7 +194,7 @@ public class CompositeJsonEncoderTest {
         verify(formatter).setContext(context);
         verify(formatter).start();
         
-        verify(prefix).setCharset(Charset.forName("UTF-8"));
+        verify(prefix).setCharset(StandardCharsets.UTF_8);
         verify(prefix).start();
         verify(suffix).start();
         
@@ -205,7 +205,7 @@ public class CompositeJsonEncoderTest {
         
         verify(formatter).writeEventToOutputStream(eq(event), any(OutputStream.class));
         
-        assertThat(encoded).containsExactly(("prefixsuffix" + System.getProperty("line.separator")).getBytes("UTF-8"));
+        assertThat(encoded).containsExactly(("prefixsuffix" + System.getProperty("line.separator")).getBytes(StandardCharsets.UTF_8));
         
         encoder.stop();
         Assert.assertFalse(encoder.isStarted());

--- a/src/test/java/net/logstash/logback/encoder/LogstashEncoderTest.java
+++ b/src/test/java/net/logstash/logback/encoder/LogstashEncoderTest.java
@@ -179,7 +179,7 @@ public class LogstashEncoderTest {
         
         byte[] encoded = encoder.encode(event);
         
-        String output = new String(encoded, "UTF-8");
+        String output = new String(encoded, StandardCharsets.UTF_8);
         
         assertThat(output).isEqualTo(String.format(
                 "{%n"
@@ -733,7 +733,7 @@ public class LogstashEncoderTest {
         MDC.remove("myMdcKey");
 
         List<String> lines = Files.linesOf(tempFile, StandardCharsets.UTF_8);
-        JsonNode node = MAPPER.readTree(lines.get(0).getBytes("UTF-8"));
+        JsonNode node = MAPPER.readTree(lines.get(0).getBytes(StandardCharsets.UTF_8));
 
         /*
          * The configuration suppresses the version field,


### PR DESCRIPTION
Hi，

Is it necessary to replace `Charset.forName("UTF-8")` or some codes like `new String(encoded, "UTF-8")` to the constant variable StandardCharsets.UTF_8 which JDK 7 has provided