### PR TITLE
Add new json provider to log root stack trace elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1818,7 +1818,7 @@ For LoggingEvents, the available providers and their configuration properties (d
           <li><tt>classFieldName</tt> - Field name for class name (<tt>caller_class_name</tt>)</li>
           <li><tt>methodFieldName</tt> - Field name for method name (<tt>caller_method_name</tt>)</li>
           <li><tt>fileFieldName</tt> - Field name for file name (<tt>caller_file_name</tt>)</li>
-          <li><tt>lineFieldName</tt> - Field name for lin number (<tt>caller_line_number</tt>)</li>
+          <li><tt>lineFieldName</tt> - Field name for line number (<tt>caller_line_number</tt>)</li>
         </ul>
       </td>
     </tr>
@@ -1828,6 +1828,15 @@ For LoggingEvents, the available providers and their configuration properties (d
         <ul>
           <li><tt>fieldName</tt> - Output field name (<tt>stack_trace</tt>)</li>
           <li><tt>throwableConverter</tt> - The <tt>ThrowableHandlingConverter</tt> to use to format the stacktrace (<tt>stack_trace</tt>)</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td><tt>rootStackTraceElement</tt></td>
+      <td><p>(Only if a throwable was logged) Outputs details (class and method name) for the root stack trace element.</p>
+        <p>This helps when indexing.</p>
+        <ul>
+          <li><tt>fieldName</tt> - Output field name (<tt>root_stack_trace_element</tt>)</li>
         </ul>
       </td>
     </tr>

--- a/src/main/java/net/logstash/logback/composite/loggingevent/LoggingEventJsonProviders.java
+++ b/src/main/java/net/logstash/logback/composite/loggingevent/LoggingEventJsonProviders.java
@@ -64,6 +64,9 @@ public class LoggingEventJsonProviders extends JsonProviders<ILoggingEvent> {
     public void addStackTrace(StackTraceJsonProvider provider) {
         addProvider(provider);
     }
+    public void addRootStackTraceElement(RootStackTraceElementJsonProvider provider) {
+        addProvider(provider);
+    }
     public void addStackHash(StackHashJsonProvider provider) {
         addProvider(provider);
     }

--- a/src/main/java/net/logstash/logback/composite/loggingevent/RootStackTraceElementJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/loggingevent/RootStackTraceElementJsonProvider.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.logstash.logback.composite.loggingevent;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.IThrowableProxy;
+import ch.qos.logback.classic.spi.ThrowableProxy;
+import com.fasterxml.jackson.core.JsonGenerator;
+import net.logstash.logback.composite.AbstractFieldJsonProvider;
+import net.logstash.logback.composite.JsonWritingUtils;
+
+import java.io.IOException;
+
+/**
+ * A JSON provider that adds a {@code rootStackTraceElement} Json field on a log with a stack trace
+ * <p>
+ *
+ * @author Daniel Albuquerque
+ */
+public class RootStackTraceElementJsonProvider extends AbstractFieldJsonProvider<ILoggingEvent> {
+
+    public static final String FIELD_CLASS_NAME = "class_name";
+    public static final String FIELD_METHOD_NAME = "method_name";
+    public static final String FIELD_STACKTRACE_ELEMENT = "root_stack_trace_element";
+
+    public RootStackTraceElementJsonProvider() {
+        setFieldName(FIELD_STACKTRACE_ELEMENT);
+    }
+
+    @Override
+    public void writeTo(JsonGenerator generator, ILoggingEvent event) throws IOException {
+        IThrowableProxy throwableProxy = event.getThrowableProxy();
+        if (throwableProxy != null && throwableProxy instanceof ThrowableProxy) {
+            if (throwableProxy.getStackTraceElementProxyArray().length > 0) {
+                StackTraceElement stackTraceElement = throwableProxy.getStackTraceElementProxyArray()[0].getStackTraceElement();
+
+                generator.writeObjectFieldStart(getFieldName());
+                JsonWritingUtils.writeStringField(generator, FIELD_CLASS_NAME, stackTraceElement.getClassName());
+                JsonWritingUtils.writeStringField(generator, FIELD_METHOD_NAME, stackTraceElement.getMethodName());
+                generator.writeEndObject();
+            }
+        }
+    }
+}

--- a/src/main/java/net/logstash/logback/composite/loggingevent/RootStackTraceElementJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/loggingevent/RootStackTraceElementJsonProvider.java
@@ -2,9 +2,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,7 +18,9 @@ import ch.qos.logback.classic.spi.IThrowableProxy;
 import ch.qos.logback.classic.spi.ThrowableProxy;
 import com.fasterxml.jackson.core.JsonGenerator;
 import net.logstash.logback.composite.AbstractFieldJsonProvider;
+import net.logstash.logback.composite.FieldNamesAware;
 import net.logstash.logback.composite.JsonWritingUtils;
+import net.logstash.logback.fieldnames.LogstashFieldNames;
 
 import java.io.IOException;
 
@@ -28,11 +30,13 @@ import java.io.IOException;
  *
  * @author Daniel Albuquerque
  */
-public class RootStackTraceElementJsonProvider extends AbstractFieldJsonProvider<ILoggingEvent> {
+public class RootStackTraceElementJsonProvider extends AbstractFieldJsonProvider<ILoggingEvent> implements FieldNamesAware<LogstashFieldNames> {
 
     public static final String FIELD_CLASS_NAME = "class_name";
     public static final String FIELD_METHOD_NAME = "method_name";
     public static final String FIELD_STACKTRACE_ELEMENT = "root_stack_trace_element";
+    private String fieldClassName = FIELD_CLASS_NAME;
+    private String fieldMethodName = FIELD_METHOD_NAME;
 
     public RootStackTraceElementJsonProvider() {
         setFieldName(FIELD_STACKTRACE_ELEMENT);
@@ -46,10 +50,24 @@ public class RootStackTraceElementJsonProvider extends AbstractFieldJsonProvider
                 StackTraceElement stackTraceElement = throwableProxy.getStackTraceElementProxyArray()[0].getStackTraceElement();
 
                 generator.writeObjectFieldStart(getFieldName());
-                JsonWritingUtils.writeStringField(generator, FIELD_CLASS_NAME, stackTraceElement.getClassName());
-                JsonWritingUtils.writeStringField(generator, FIELD_METHOD_NAME, stackTraceElement.getMethodName());
+                JsonWritingUtils.writeStringField(generator, fieldClassName, stackTraceElement.getClassName());
+                JsonWritingUtils.writeStringField(generator, fieldMethodName, stackTraceElement.getMethodName());
                 generator.writeEndObject();
             }
         }
+    }
+
+    @Override
+    public void setFieldNames(LogstashFieldNames fieldNames) {
+        setFieldClassName(fieldNames.getRootStackTraceElementClass());
+        setFieldMethodName(fieldNames.getRootStackTraceElementMethod());
+    }
+
+    private void setFieldClassName(String fieldClassName) {
+        this.fieldClassName = fieldClassName;
+    }
+
+    private void setFieldMethodName(String fieldMethodName) {
+        this.fieldMethodName = fieldMethodName;
     }
 }

--- a/src/main/java/net/logstash/logback/fieldnames/LogstashFieldNames.java
+++ b/src/main/java/net/logstash/logback/fieldnames/LogstashFieldNames.java
@@ -17,6 +17,7 @@ import net.logstash.logback.composite.loggingevent.CallerDataJsonProvider;
 import net.logstash.logback.composite.loggingevent.LogLevelJsonProvider;
 import net.logstash.logback.composite.loggingevent.LogLevelValueJsonProvider;
 import net.logstash.logback.composite.loggingevent.LoggerNameJsonProvider;
+import net.logstash.logback.composite.loggingevent.RootStackTraceElementJsonProvider;
 import net.logstash.logback.composite.loggingevent.StackTraceJsonProvider;
 import net.logstash.logback.composite.loggingevent.TagsJsonProvider;
 import net.logstash.logback.composite.loggingevent.ThreadNameJsonProvider;
@@ -37,6 +38,8 @@ public class LogstashFieldNames extends LogstashCommonFieldNames {
     private String callerFile = CallerDataJsonProvider.FIELD_CALLER_FILE_NAME;
     private String callerLine = CallerDataJsonProvider.FIELD_CALLER_LINE_NUMBER;
     private String stackTrace = StackTraceJsonProvider.FIELD_STACK_TRACE;
+    private String rootStackTraceElementClass = RootStackTraceElementJsonProvider.FIELD_CLASS_NAME;
+    private String rootStackTraceElementMethod = RootStackTraceElementJsonProvider.FIELD_METHOD_NAME;
     private String tags = TagsJsonProvider.FIELD_TAGS;
     private String mdc;
     private String context;
@@ -194,5 +197,21 @@ public class LogstashFieldNames extends LogstashCommonFieldNames {
 
     public void setUuid(String uuid) {
         this.uuid = uuid;
+    }
+
+    public String getRootStackTraceElementMethod() {
+        return rootStackTraceElementMethod;
+    }
+
+    public void setRootStackTraceElementMethod(String rootStackTraceElementMethod) {
+        this.rootStackTraceElementMethod = rootStackTraceElementMethod;
+    }
+
+    public String getRootStackTraceElementClass() {
+        return rootStackTraceElementClass;
+    }
+
+    public void setRootStackTraceElementClass(String rootStackTraceElementClass) {
+        this.rootStackTraceElementClass = rootStackTraceElementClass;
     }
 }

--- a/src/main/java/net/logstash/logback/fieldnames/ShortenedFieldNames.java
+++ b/src/main/java/net/logstash/logback/fieldnames/ShortenedFieldNames.java
@@ -41,6 +41,8 @@ public class ShortenedFieldNames extends LogstashFieldNames {
         setCallerFile(FIELD_FILE);
         setCallerLine(FIELD_LINE);
         setStackTrace(FIELD_STACKTRACE);
+        setRootStackTraceElementClass(FIELD_CLASS);
+        setRootStackTraceElementMethod(FIELD_METHOD);
     }
     
 }

--- a/src/test/java/net/logstash/logback/composite/loggingevent/ExceptionRootCauseMethodNameJsonProviderTest.java
+++ b/src/test/java/net/logstash/logback/composite/loggingevent/ExceptionRootCauseMethodNameJsonProviderTest.java
@@ -1,0 +1,72 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.logstash.logback.composite.loggingevent;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.StackTraceElementProxy;
+import ch.qos.logback.classic.spi.ThrowableProxy;
+import com.fasterxml.jackson.core.JsonGenerator;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.when;
+
+public class ExceptionRootCauseMethodNameJsonProviderTest {
+
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
+    private RootStackTraceElementJsonProvider provider = new RootStackTraceElementJsonProvider();
+
+    @Mock
+    private JsonGenerator generator;
+
+    @Mock
+    private ILoggingEvent event;
+
+    @Mock
+    private ThrowableProxy throwableProxy;
+
+    @Mock
+    private StackTraceElementProxy steProxy;
+
+    private StackTraceElement ste = new StackTraceElement("TestDeclaringClass", "testMethodName", "testFileName", 0);
+
+    @Test
+    public void testStackTraceElementIsWritten() throws IOException {
+        // GIVEN
+        when(event.getThrowableProxy()).thenReturn(throwableProxy);
+        StackTraceElementProxy[] steArray = new StackTraceElementProxy[]{steProxy};
+        when(throwableProxy.getStackTraceElementProxyArray()).thenReturn(steArray);
+        when(steProxy.getStackTraceElement()).thenReturn(ste);
+        provider.setFieldName(RootStackTraceElementJsonProvider.FIELD_STACKTRACE_ELEMENT);
+        // WHEN
+        provider.writeTo(generator, event);
+        // THEN
+        InOrder inOrder = inOrder(generator);
+
+        inOrder.verify(generator).writeObjectFieldStart(RootStackTraceElementJsonProvider.FIELD_STACKTRACE_ELEMENT);
+        inOrder.verify(generator).writeStringField(RootStackTraceElementJsonProvider.FIELD_CLASS_NAME, "TestDeclaringClass");
+        inOrder.verify(generator).writeStringField(RootStackTraceElementJsonProvider.FIELD_METHOD_NAME, "testMethodName");
+        inOrder.verify(generator).writeEndObject();
+    }
+}

--- a/src/test/java/net/logstash/logback/composite/loggingevent/RootStackTraceElementJsonProviderTest.java
+++ b/src/test/java/net/logstash/logback/composite/loggingevent/RootStackTraceElementJsonProviderTest.java
@@ -2,22 +2,22 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package net.logstash.logback.composite.loggingevent;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.StackTraceElementProxy;
 import ch.qos.logback.classic.spi.ThrowableProxy;
 import com.fasterxml.jackson.core.JsonGenerator;
+import net.logstash.logback.fieldnames.ShortenedFieldNames;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.InOrder;
@@ -30,7 +30,7 @@ import java.io.IOException;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.when;
 
-public class ExceptionRootCauseMethodNameJsonProviderTest {
+public class RootStackTraceElementJsonProviderTest {
 
     @Rule
     public MockitoRule rule = MockitoJUnit.rule();
@@ -67,6 +67,25 @@ public class ExceptionRootCauseMethodNameJsonProviderTest {
         inOrder.verify(generator).writeObjectFieldStart(RootStackTraceElementJsonProvider.FIELD_STACKTRACE_ELEMENT);
         inOrder.verify(generator).writeStringField(RootStackTraceElementJsonProvider.FIELD_CLASS_NAME, "TestDeclaringClass");
         inOrder.verify(generator).writeStringField(RootStackTraceElementJsonProvider.FIELD_METHOD_NAME, "testMethodName");
+        inOrder.verify(generator).writeEndObject();
+    }
+
+    @Test
+    public void testOverrideFieldNameWithShortNames() throws IOException {
+        // GIVEN
+        when(event.getThrowableProxy()).thenReturn(throwableProxy);
+        StackTraceElementProxy[] steArray = new StackTraceElementProxy[]{steProxy};
+        when(throwableProxy.getStackTraceElementProxyArray()).thenReturn(steArray);
+        when(steProxy.getStackTraceElement()).thenReturn(ste);
+        provider.setFieldNames(new ShortenedFieldNames());
+        // WHEN
+        provider.writeTo(generator, event);
+        // THEN
+        InOrder inOrder = inOrder(generator);
+
+        inOrder.verify(generator).writeObjectFieldStart(RootStackTraceElementJsonProvider.FIELD_STACKTRACE_ELEMENT);
+        inOrder.verify(generator).writeStringField(ShortenedFieldNames.FIELD_CLASS, "TestDeclaringClass");
+        inOrder.verify(generator).writeStringField(ShortenedFieldNames.FIELD_METHOD, "testMethodName");
         inOrder.verify(generator).writeEndObject();
     }
 }


### PR DESCRIPTION
Hi 👋

I'm opening a draft for a new json provider.
It complements existing ones (ThrowableRootCauseClassNameJsonProvider, StackTraceJsonProvider, ...).
This provides details about the context of the exception, ie, it doesn't tell us that a NullPointerException occurred but rather that it occurred in MyClass.myMethod().

For example, `MyClass.doSomething()` calling `MyOtherClass.doSomethingRisky()` which throws an error will produce the following output.

```json
{
   "root_stack_trace_element":{
      "class_name":"com.example.stacktraces.MyOtherClass",
      "method_name":"doSomethingRisky"
   }
}
```