### PR TITLE
Add option to split log messages on newlines - fixes #404

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The structure of the output, and the data it contains, is fully configurable.
 * [Customizing Standard Field Names](#customizing-standard-field-names)
 * [Customizing Version](#customizing-version)
 * [Customizing Timestamp](#customizing-timestamp)
+* [Customizing Message](#customizing-message)
 * [Customizing Logger Name Length](#customizing-logger-name-length)
 * [Customizing Stack Traces](#customizing-stack-traces)
 * [Prefix/Suffix/Separator](#prefixsuffixseparator)
@@ -847,9 +848,9 @@ The field names can be customized (see [Customizing Standard Field Names](#custo
 
 | Field         | Description
 |---------------|------------
-| `@timestamp`  | Time of the log event. (`yyyy-MM-dd'T'HH:mm:ss.SSSZZ`)  See [customizing timestamp](#customizing-timestamp).
-| `@version`    | Logstash format version (e.g. `1`)   See [customizing version](#customizing-version).
-| `message`     | Formatted log message of the event
+| `@timestamp`  | Time of the log event (`yyyy-MM-dd'T'HH:mm:ss.SSSZZ`) - see [Customizing Timestamp](#customizing-timestamp)
+| `@version`    | Logstash format version (e.g. `1`) - see [Customizing Version](#customizing-version)
+| `message`     | Formatted log message of the event - see [Customizing Message](#customizing-message)
 | `logger_name` | Name of the logger that logged the event
 | `thread_name` | Name of the thread that logged the event
 | `level`       | String name of the level of the event
@@ -1509,7 +1510,6 @@ For AccessEvents, see [`LogstashAccessFieldNames`](/src/main/java/net/logstash/l
 for all the field names that can be customized. Each java field name in that class is the name of the xml element that you would use to specify the field name (e.g. `fieldsMethod`, `fieldsProtocol`).
 
 
-
 ## Customizing Version
 
 The version field value by default is the string value `1`.
@@ -1563,6 +1563,41 @@ For example:
 ```xml
 <encoder class="net.logstash.logback.encoder.LogstashEncoder">
   <timestampPattern>[UNIX_TIMESTAMP_AS_NUMBER]</timestampPattern>
+</encoder>
+```
+
+
+## Customizing Message
+
+By default, messages are written as JSON strings. Any characters not allowed in a JSON string, such as newlines, are escaped.
+See the [Customizing Character Escapes](#customizing-character-escapes) section for details.
+
+You can also write messages as JSON arrays instead of strings, by specifying a `messageSplitRegex` to split the message text.
+This configuration element can take the following values:
+
+* any valid regex pattern
+* `SYSTEM` (uses the system-default line separator)
+* `UNIX` (uses `\n`)
+* `WINDOWS` (uses `\r\n`)
+
+If you split the log message by the origin system's line separator, the written message does not contain any embedded line separators.
+The target system can unambiguously parse the message without any knowledge of the origin system's line separators.
+
+For example:
+
+```xml
+<encoder class="net.logstash.logback.encoder.LogstashEncoder">
+  <messageSplitRegex>SYSTEM</messageSplitRegex>
+</encoder>
+```
+```xml
+<encoder class="net.logstash.logback.encoder.LogstashEncoder">
+  <messageSplitRegex>\r?\n</messageSplitRegex>
+</encoder>
+```
+```xml
+<encoder class="net.logstash.logback.encoder.LogstashEncoder">
+  <messageSplitRegex>#+</messageSplitRegex>
 </encoder>
 ```
 
@@ -1778,6 +1813,9 @@ For LoggingEvents, the available providers and their configuration properties (d
       <td><p>Formatted log event message</p>
         <ul>
           <li><tt>fieldName</tt> - Output field name (<tt>message</tt>)</li>
+          <li><tt>messageSplitRegex</tt> - If null or empty, write the message text as is (the default behavior).
+              Otherwise, split the message text using the specified regex and write it as an array.
+              See the <a href="#customizing-message">Customizing Message</a> section for details.</li>
         </ul>
       </td>
     </tr>

--- a/src/main/java/net/logstash/logback/LogstashFormatter.java
+++ b/src/main/java/net/logstash/logback/LogstashFormatter.java
@@ -416,6 +416,53 @@ public class LogstashFormatter extends LoggingEventCompositeJsonFormatter {
         }
     }
     
+    /**
+     * Write the message as a JSON array by splitting the message text using the specified regex.
+     *
+     * @return The regex used to split the message text
+     */
+    public String getMessageSplitRegex() {
+        return messageProvider.getMessageSplitRegex();
+    }
+
+    /**
+     * Write the message as a JSON array by splitting the message text using the specified regex.
+     *
+     * <p>
+     * The allowed values are:
+     * <ul>
+     *     <li>Null/Empty : Disable message splitting. This is also the default behavior.</li>
+     *     <li>Any valid regex : Use the specified regex.</li>
+     *     <li><tt>SYSTEM</tt> : Use the system-default line separator.</li>
+     *     <li><tt>UNIX</tt> : Use <tt>\n</tt>.</li>
+     *     <li><tt>WINDOWS</tt> : Use <tt>\r\n</tt>.</li>
+     * </ul>
+     * </p>
+     * <p>
+     * For example, if this parameter is set to the regex {@code #+}, then the logging statement:
+     * <pre>
+     * log.info("First line##Second line###Third line")
+     * </pre>
+     * will produce:
+     * <pre>
+     * {
+     *     ...
+     *     "message": [
+     *         "First line",
+     *         "Second line",
+     *         "Third line"
+     *     ],
+     *     ...
+     * }
+     * </pre>
+     * </p>
+     *
+     * @param messageSplitRegex The regex used to split the message text
+     */
+    public void setMessageSplitRegex(String messageSplitRegex) {
+        messageProvider.setMessageSplitRegex(messageSplitRegex);
+    }
+
     public void addProvider(JsonProvider<ILoggingEvent> provider) {
         if (provider instanceof ArgumentsJsonProvider) {
             getProviders().removeProvider(this.argumentsProvider);

--- a/src/main/java/net/logstash/logback/composite/JsonWritingUtils.java
+++ b/src/main/java/net/logstash/logback/composite/JsonWritingUtils.java
@@ -62,6 +62,19 @@ public class JsonWritingUtils {
     }
     
     /**
+     * Writes an array of strings to the generator if and only if the fieldName and values are not null.
+     */
+    public static void writeStringArrayField(JsonGenerator generator, String fieldName, String[] fieldValues) throws IOException {
+        if (shouldWriteField(fieldName) && fieldValues != null && fieldValues.length > 0) {
+            generator.writeArrayFieldStart(fieldName);
+            for (String fieldValue : fieldValues) {
+                generator.writeString(fieldValue);
+            }
+            generator.writeEndArray();
+        }
+    }
+
+    /**
      * Writes the field to the generator if and only if the fieldName and fieldValue are not null.
      */
     public static void writeStringField(JsonGenerator generator, String fieldName, String fieldValue) throws IOException {

--- a/src/main/java/net/logstash/logback/encoder/LogstashEncoder.java
+++ b/src/main/java/net/logstash/logback/encoder/LogstashEncoder.java
@@ -255,5 +255,50 @@ public class LogstashEncoder extends LoggingEventCompositeJsonEncoder {
         getFormatter().setWriteVersionAsInteger(writeVersionAsInteger);
     }
     
+    /**
+     * Write the message as a JSON array by splitting the message text using the specified regex.
+     *
+     * @return The regex used to split the message text
+     */
+    public String getMessageSplitRegex() {
+        return getFormatter().getMessageSplitRegex();
+    }
 
+    /**
+     * Write the message as a JSON array by splitting the message text using the specified regex.
+     *
+     * <p>
+     * The allowed values are:
+     * <ul>
+     *     <li>Null/Empty : Disable message splitting. This is also the default behavior.</li>
+     *     <li>Any valid regex : Use the specified regex.</li>
+     *     <li><tt>SYSTEM</tt> : Use the system-default line separator.</li>
+     *     <li><tt>UNIX</tt> : Use <tt>\n</tt>.</li>
+     *     <li><tt>WINDOWS</tt> : Use <tt>\r\n</tt>.</li>
+     * </ul>
+     * </p>
+     * <p>
+     * For example, if this parameter is set to the regex {@code #+}, then the logging statement:
+     * <pre>
+     * log.info("First line##Second line###Third line")
+     * </pre>
+     * will produce:
+     * <pre>
+     * {
+     *     ...
+     *     "message": [
+     *         "First line",
+     *         "Second line",
+     *         "Third line"
+     *     ],
+     *     ...
+     * }
+     * </pre>
+     * </p>
+     *
+     * @param messageSplitRegex The regex used to split the message text
+     */
+    public void setMessageSplitRegex(String messageSplitRegex) {
+        getFormatter().setMessageSplitRegex(messageSplitRegex);
+    }
 }

--- a/src/main/java/net/logstash/logback/layout/LogstashLayout.java
+++ b/src/main/java/net/logstash/logback/layout/LogstashLayout.java
@@ -219,5 +219,50 @@ public class LogstashLayout extends LoggingEventCompositeJsonLayout {
         getFormatter().setWriteVersionAsInteger(writeVersionAsInteger);
     }
     
+    /**
+     * Write the message as a JSON array by splitting the message text using the specified regex.
+     *
+     * @return The regex used to split the message text
+     */
+    public String getMessageSplitRegex() {
+        return getFormatter().getMessageSplitRegex();
+    }
 
+    /**
+     * Write the message as a JSON array by splitting the message text using the specified regex.
+     *
+     * <p>
+     * The allowed values are:
+     * <ul>
+     *     <li>Null/Empty : Disable message splitting. This is also the default behavior.</li>
+     *     <li>Any valid regex : Use the specified regex.</li>
+     *     <li><tt>SYSTEM</tt> : Use the system-default line separator.</li>
+     *     <li><tt>UNIX</tt> : Use <tt>\n</tt>.</li>
+     *     <li><tt>WINDOWS</tt> : Use <tt>\r\n</tt>.</li>
+     * </ul>
+     * </p>
+     * <p>
+     * For example, if this parameter is set to the regex {@code #+}, then the logging statement:
+     * <pre>
+     * log.info("First line##Second line###Third line")
+     * </pre>
+     * will produce:
+     * <pre>
+     * {
+     *     ...
+     *     "message": [
+     *         "First line",
+     *         "Second line",
+     *         "Third line"
+     *     ],
+     *     ...
+     * }
+     * </pre>
+     * </p>
+     *
+     * @param messageSplitRegex The regex used to split the message text
+     */
+    public void setMessageSplitRegex(String messageSplitRegex) {
+        getFormatter().setMessageSplitRegex(messageSplitRegex);
+    }
 }

--- a/src/test/java/net/logstash/logback/encoder/LogstashEncoderTest.java
+++ b/src/test/java/net/logstash/logback/encoder/LogstashEncoderTest.java
@@ -17,6 +17,11 @@ import static ch.qos.logback.core.CoreConstants.LINE_SEPARATOR;
 import static net.logstash.logback.marker.Markers.append;
 import static net.logstash.logback.marker.Markers.appendEntries;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -40,7 +45,6 @@ import net.logstash.logback.fieldnames.ShortenedFieldNames;
 
 import org.apache.commons.lang3.time.FastDateFormat;
 import org.assertj.core.util.Files;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -603,8 +607,8 @@ public class LogstashEncoderTest {
         JsonNode node = MAPPER.readTree(encoded);
         
         assertThat(node.get("appname").textValue()).isEqualTo("damnGodWebservice");
-        Assert.assertTrue(node.get("roles").equals(parse("[\"customerorder\", \"auth\"]")));
-        Assert.assertTrue(node.get("buildinfo").equals(parse("{ \"version\" : \"Version 0.1.0-SNAPSHOT\", \"lastcommit\" : \"75473700d5befa953c45f630c6d9105413c16fe1\"}")));
+        assertTrue(node.get("roles").equals(parse("[\"customerorder\", \"auth\"]")));
+        assertTrue(node.get("buildinfo").equals(parse("{ \"version\" : \"Version 0.1.0-SNAPSHOT\", \"lastcommit\" : \"75473700d5befa953c45f630c6d9105413c16fe1\"}")));
     }
     
     @Test
@@ -746,8 +750,8 @@ public class LogstashEncoderTest {
         assertThat(node.get("appendedName").textValue()).isEqualTo("appendedValue");
         assertThat(node.get("myMdcKey")).isNull();
         assertThat(node.get("logger").textValue()).isEqualTo(LogstashEncoderTest.class.getName());
-        Assert.assertTrue(node.get("roles").equals(parse("[\"customerorder\", \"auth\"]")));
-        Assert.assertTrue(node.get("buildinfo").equals(parse("{ \"version\" : \"Version 0.1.0-SNAPSHOT\", \"lastcommit\" : \"75473700d5befa953c45f630c6d9105413c16fe1\"}")));
+        assertTrue(node.get("roles").equals(parse("[\"customerorder\", \"auth\"]")));
+        assertTrue(node.get("buildinfo").equals(parse("{ \"version\" : \"Version 0.1.0-SNAPSHOT\", \"lastcommit\" : \"75473700d5befa953c45f630c6d9105413c16fe1\"}")));
     }
     
     @Test
@@ -790,13 +794,58 @@ public class LogstashEncoderTest {
         assertThat(node.get("@timestamp").textValue()).isEqualTo(Long.toString(timestamp));
     }    
     
+    @Test
+    public void testMessageSplitEnabled() throws Exception {
+        ILoggingEvent event = mockBasicILoggingEvent(Level.ERROR);
+        when(event.getFormattedMessage()).thenReturn(buildMultiLineMessage("###"));
+        encoder.setMessageSplitRegex("#+");
+        assertEquals("#+", encoder.getMessageSplitRegex());
+
+        encoder.start();
+        JsonNode node = MAPPER.readTree(encoder.encode(event));
+        encoder.stop();
+
+        assertJsonArray(node.path("message"), "line1", "line2", "line3");
+    }
+
+    @Test
+    public void testMessageSplitDisabled() throws Exception {
+        ILoggingEvent event = mockBasicILoggingEvent(Level.ERROR);
+        when(event.getFormattedMessage()).thenReturn(buildMultiLineMessage(System.lineSeparator()));
+        encoder.setMessageSplitRegex(null);
+        assertNull(encoder.getMessageSplitRegex());
+
+        encoder.start();
+        JsonNode node = MAPPER.readTree(encoder.encode(event));
+        encoder.stop();
+
+        assertTrue(node.path("message").isTextual());
+        assertEquals(node.path("message").textValue(), buildMultiLineMessage(System.lineSeparator()));
+    }
+
+    @Test
+    public void testMessageSplitDisabledByDefault() throws Exception {
+        ILoggingEvent event = mockBasicILoggingEvent(Level.ERROR);
+        when(event.getFormattedMessage()).thenReturn(buildMultiLineMessage(System.lineSeparator()));
+        assertNull(encoder.getMessageSplitRegex());
+
+        encoder.start();
+        JsonNode node = MAPPER.readTree(encoder.encode(event));
+        encoder.stop();
+
+        assertTrue(node.path("message").isTextual());
+        assertEquals(node.path("message").textValue(), buildMultiLineMessage(System.lineSeparator()));
+    }
+
     private void assertJsonArray(JsonNode jsonNode, String... expected) {
+        assertNotNull(jsonNode);
+        assertTrue(jsonNode.isArray());
+
         String[] values = new String[jsonNode.size()];
         for (int i = 0; i < values.length; i++) {
             values[i] = jsonNode.get(i).asText();
         }
-        
-        Assert.assertArrayEquals(expected, values);
+        assertArrayEquals(expected, values);
     }
     
     private ILoggingEvent mockBasicILoggingEvent(Level level) {
@@ -808,4 +857,7 @@ public class LogstashEncoderTest {
         return event;
     }
     
+    private static String buildMultiLineMessage(String lineSeparator) {
+        return String.join(lineSeparator, "line1", "line2", "line3");
+    }
 }


### PR DESCRIPTION
This PR adds an option to output the `"message"` field as a JSON array, instead of a JSON string.

For example, with either of these logging statements:

```java
logger.error("first line{}second line", System.lineSeparator());
// or
logger.error("first line\nsecond line");
// or
logger.error("first line\r\nsecond line");
```

The output is consistent:

```yaml
{
    "message": [
        "first line",
        "second line"
    ],
    ...
}
```

This provides an unambiguous parsing format on the target system instead of relying on the source platform's newline representation.