### PR TITLE
Added stacktrace field name adjustment example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1488,6 +1488,7 @@ For example:
   <fieldNames>
     <timestamp>time</timestamp>
     <message>msg</message>
+    <stackTrace>stacktrace</stackTrace>
     ...
   </fieldNames>
 </encoder>


### PR DESCRIPTION
This PR adds the one example for the adjustment of the `stack_trace` field name into the README.

It took me quite a little bit of time to understand how this XML needs to be called:

* `<stacktrace />`
* `<stackTrace />`
* `<stack_trace />`

I think this simplifies the adjustment of it a little (it would certainly have helped me via looking into the example).