### PR TITLE
Close JsonGenerators after usage.

### DIFF
--- a/src/main/java/net/logstash/logback/composite/CompositeJsonFormatter.java
+++ b/src/main/java/net/logstash/logback/composite/CompositeJsonFormatter.java
@@ -161,8 +161,9 @@ public abstract class CompositeJsonFormatter<Event extends DeferredProcessingAwa
     }
 
     public void writeEventToOutputStream(Event event, OutputStream outputStream) throws IOException {
-        JsonGenerator generator = createGenerator(outputStream);
-        writeEventToGenerator(generator, event);
+        try (JsonGenerator generator = createGenerator(outputStream)) {
+            writeEventToGenerator(generator, event);
+        }
         /*
          * Do not flush the outputStream.
          * 
@@ -174,10 +175,11 @@ public abstract class CompositeJsonFormatter<Event extends DeferredProcessingAwa
     public String writeEventAsString(Event event) throws IOException {
         SegmentedStringWriter writer = new SegmentedStringWriter(getBufferRecycler());
 
-        JsonGenerator generator = createGenerator(writer);
-        writeEventToGenerator(generator, event);
-        writer.flush();
-        return writer.getAndClear();
+        try (JsonGenerator generator = createGenerator(writer)) {
+            writeEventToGenerator(generator, event);
+            writer.flush();
+            return writer.getAndClear();
+        }
     }
 
     protected void writeEventToGenerator(JsonGenerator generator, Event event) throws IOException {


### PR DESCRIPTION
In general `JsonGenerator` should be closed, so that Jackson can recycle buffers etc..

It looks like `logstash-logback-encoder` does it own buffer management, so I am not sure if it is necessary.

Sorry for the noise if this is irrelevant.