### PR TITLE
Make DelegatingAsyncDisruptorAppender more resilient to exceptions + flush Flushable appenders at end of batch

### DIFF
--- a/src/main/java/net/logstash/logback/appender/DelegatingAsyncDisruptorAppender.java
+++ b/src/main/java/net/logstash/logback/appender/DelegatingAsyncDisruptorAppender.java
@@ -57,66 +57,66 @@ public abstract class DelegatingAsyncDisruptorAppender<Event extends DeferredPro
         /**
          * Whether exceptions should be reported with a error status or not.
          */
-    	private boolean silentError;
+        private boolean silentError;
         
         @Override
         public void onEvent(LogEvent<Event> logEvent, long sequence, boolean endOfBatch) throws Exception {
             
             boolean exceptionThrown = false;
-			for(Iterator<Appender<Event>> it=appenders.iteratorForAppenders(); it.hasNext(); ) {
-				Appender<Event> appender = it.next();
-				
-				try {
-					appender.doAppend(logEvent.event);
-					
-		            /*
-		             * Optimization:
-		             *
-		             * If any of the delegate appenders are instances of OutputStreamAppender or Flushable,
-		             * then flush them at the end of the batch.
-		             */
-					if (endOfBatch) {
-						flushAppender(appender);
-					}
-				}
-				catch(Exception e) {
-					exceptionThrown = true;
-					if (!this.silentError) {
-						addError(String.format("Unable to forward event to appender [%s]: %s", appender.getName(), e.getMessage()), e);
-					}
-				}
-			}
-			
-			this.silentError = exceptionThrown;
+            for(Iterator<Appender<Event>> it=appenders.iteratorForAppenders(); it.hasNext(); ) {
+                Appender<Event> appender = it.next();
+                
+                try {
+                    appender.doAppend(logEvent.event);
+                    
+                    /*
+                     * Optimization:
+                     *
+                     * If any of the delegate appenders are instances of OutputStreamAppender or Flushable,
+                     * then flush them at the end of the batch.
+                     */
+                    if (endOfBatch) {
+                        flushAppender(appender);
+                    }
+                }
+                catch(Exception e) {
+                    exceptionThrown = true;
+                    if (!this.silentError) {
+                        addError(String.format("Unable to forward event to appender [%s]: %s", appender.getName(), e.getMessage()), e);
+                    }
+                }
+            }
+            
+            this.silentError = exceptionThrown;
         }
         
         
         private void flushAppender(Appender<Event> appender) throws IOException {
-        	// Similar to #doAppend() - don't flush if appender is stopped
-        	if (!appender.isStarted()) {
-        		return;
-        	}
-			if (appender instanceof Flushable) {
-				flushAppender((Flushable)appender);
-			}
-			else
-			if (appender instanceof OutputStreamAppender) {
-				flushAppender((OutputStreamAppender<Event>)appender);
-			}
+            // Similar to #doAppend() - don't flush if appender is stopped
+            if (!appender.isStarted()) {
+                return;
+            }
+            if (appender instanceof Flushable) {
+                flushAppender((Flushable)appender);
+            }
+            else
+            if (appender instanceof OutputStreamAppender) {
+                flushAppender((OutputStreamAppender<Event>)appender);
+            }
         }
-		
-		private void flushAppender(OutputStreamAppender<Event> appender) throws IOException {
-			if (!appender.isImmediateFlush()) {
-				OutputStream os = appender.getOutputStream();
-				if (os != null) {
-					os.flush();
-				}
-			}
-		}
-		
-		private void flushAppender(Flushable appender) throws IOException {
-			appender.flush();
-		}
+        
+        private void flushAppender(OutputStreamAppender<Event> appender) throws IOException {
+            if (!appender.isImmediateFlush()) {
+                OutputStream os = appender.getOutputStream();
+                if (os != null) {
+                    os.flush();
+                }
+            }
+        }
+        
+        private void flushAppender(Flushable appender) throws IOException {
+            appender.flush();
+        }
     }
     
     public DelegatingAsyncDisruptorAppender() {

--- a/src/test/java/net/logstash/logback/appender/DelegatingAsyncDisruptorAppenderTest.java
+++ b/src/test/java/net/logstash/logback/appender/DelegatingAsyncDisruptorAppenderTest.java
@@ -13,42 +13,53 @@
  */
 package net.logstash.logback.appender;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.ByteArrayOutputStream;
+import java.io.Flushable;
+import java.io.IOException;
 import java.io.OutputStream;
-
-import ch.qos.logback.core.OutputStreamAppender;
-import net.logstash.logback.appender.listener.AppenderListener;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
+import ch.qos.logback.core.AppenderBase;
+import ch.qos.logback.core.LogbackException;
+import ch.qos.logback.core.OutputStreamAppender;
+import ch.qos.logback.core.encoder.EchoEncoder;
+import net.logstash.logback.appender.listener.AppenderListener;
 
 @ExtendWith(MockitoExtension.class)
 public class DelegatingAsyncDisruptorAppenderTest {
-    
+
     private static final int VERIFICATION_TIMEOUT = 1000 * 30;
 
     @InjectMocks
     private DelegatingAsyncDisruptorAppender<ILoggingEvent, AppenderListener<ILoggingEvent>> appender = new DelegatingAsyncDisruptorAppender<ILoggingEvent, AppenderListener<ILoggingEvent>>() {};
-    
+
     @Mock
     private ILoggingEvent event;
 
-    @Mock
-    private Appender<ILoggingEvent> delegate;
-
-    @Mock
+    @Spy
     private OutputStreamAppender<ILoggingEvent> outputStreamDelegate;
 
     @Mock
@@ -56,58 +67,248 @@ public class DelegatingAsyncDisruptorAppenderTest {
 
     @BeforeEach
     public void setup() {
-        appender.addAppender(delegate);
+        outputStreamDelegate.setImmediateFlush(false);
+        outputStreamDelegate.setEncoder(new EchoEncoder<ILoggingEvent>());
+        outputStreamDelegate.setOutputStream(outputStream);
+
+        appender.setContext(new LoggerContext());
     }
-    
+
     @AfterEach
     public void tearDown() {
         appender.stop();
     }
 
+
     @Test
-    public void testEventHandlerCalled() throws Exception {
+    public void appenderStartStop() {
+        Appender<ILoggingEvent> delegate1 = spy(new TestAppender<ILoggingEvent>());
+        Appender<ILoggingEvent> delegate2 = spy(new TestAppender<ILoggingEvent>());
+
+        appender.addAppender(delegate1);
+        appender.addAppender(delegate2);
+
+        //
+        // START
+        //
         appender.start();
+        assertThat(appender.isStarted()).isTrue();
+        verify(delegate1).start();
+        verify(delegate2).start();
 
-        verify(delegate).start();
+        // Already started - start() not called a second time on child appenders
+        appender.start();
+        verify(delegate1, times(1)).start();
+        verify(delegate2, times(1)).start();
 
-        appender.append(event);
 
-        verify(delegate, timeout(VERIFICATION_TIMEOUT)).doAppend(event);
+        //
+        // STOP
+        //
+        appender.stop();
+        verify(delegate1).stop();
+        verify(delegate2).stop();
+
+        // Already stopped - stop() not called a second time on child appenders
+        appender.stop();
+        verify(delegate1, times(1)).stop();
+        verify(delegate2, times(1)).stop();
     }
 
+
+    /*
+     * Event is forwarded to appenders in the order they were registered.
+     */
     @Test
-    public void testFlushed() throws Exception {
+    public void handlerCalled() throws Exception {
+        Appender<ILoggingEvent> delegate1 = spy(new TestAppender<ILoggingEvent>());
+        Appender<ILoggingEvent> delegate2 = spy(new TestAppender<ILoggingEvent>());
 
-        when(outputStreamDelegate.getOutputStream()).thenReturn(outputStream);
-
-        appender.addAppender(outputStreamDelegate);
-
+        appender.addAppender(delegate1);
+        appender.addAppender(delegate2);
         appender.start();
-
-        verify(delegate).start();
 
         appender.append(event);
 
-        verify(delegate, timeout(VERIFICATION_TIMEOUT)).doAppend(event);
-
-        verify(outputStream, timeout(VERIFICATION_TIMEOUT)).flush();
+        InOrder inOrder = inOrder(delegate1, delegate2);
+        inOrder.verify(delegate1, timeout(VERIFICATION_TIMEOUT)).doAppend(event);
+        inOrder.verify(delegate2, timeout(VERIFICATION_TIMEOUT)).doAppend(event);
     }
 
+
+    /*
+     * Event is forwarded to all appenders even after first threw an exception
+     */
     @Test
-    public void testNotFlushedWhenImmediateFlush() throws Exception {
+    public void handlerCalledAfterException() throws Exception {
+        Appender<ILoggingEvent> delegate1 = spy(new TestAppender<ILoggingEvent>());
+        LogbackException exception = new LogbackException("boum");
+        doThrow(exception).when(delegate1).doAppend(event);
 
-        when(outputStreamDelegate.isImmediateFlush()).thenReturn(true);
+        Appender<ILoggingEvent> delegate2 = spy(new TestAppender<ILoggingEvent>());
 
-        appender.addAppender(outputStreamDelegate);
-
+        appender.addAppender(delegate1);
+        appender.addAppender(delegate2);
         appender.start();
-
-        verify(delegate).start();
 
         appender.append(event);
 
-        verify(delegate, timeout(VERIFICATION_TIMEOUT)).doAppend(event);
+        // second appender received the event although first threw an exception
+        //
+        verify(delegate1, timeout(VERIFICATION_TIMEOUT).times(1)).doAppend(event);
+        verify(delegate2, timeout(VERIFICATION_TIMEOUT).times(1)).doAppend(event);
+
+        // an error status is logged
+        assertThat(appender.getStatusManager().getCount()).isEqualTo(1);
+        assertThat(appender.getStatusManager().getCopyOfStatusList().get(0).getOrigin()).isEqualTo(appender);
+        assertThat(appender.getStatusManager().getCopyOfStatusList().get(0).getThrowable()).isEqualTo(exception);
+
+
+        // Append one more event -> no more error statuses
+        //
+        appender.append(event);
+
+        verify(delegate1, timeout(VERIFICATION_TIMEOUT).times(2)).doAppend(event);
+        verify(delegate2, timeout(VERIFICATION_TIMEOUT).times(2)).doAppend(event);
+        assertThat(appender.getStatusManager().getCount()).isEqualTo(1);
+
+
+        // This event won't throw any exception -> reset "error state"
+        //
+        appender.append(mock(ILoggingEvent.class));
+
+
+        // This event will again trigger an exception -> a new error status is logged
+        //
+        appender.append(event);
+
+        verify(delegate1, timeout(VERIFICATION_TIMEOUT).times(3)).doAppend(event);
+        verify(delegate2, timeout(VERIFICATION_TIMEOUT).times(3)).doAppend(event);
+        assertThat(appender.getStatusManager().getCount()).isEqualTo(2);
+    }
+
+
+    /*
+     * Flush OutputStreamAppender at end of batch
+     */
+    @Test
+    public void flushOutputStreamAppender() throws Exception {
+        outputStreamDelegate.setImmediateFlush(false);
+
+        appender.addAppender(outputStreamDelegate);
+        appender.start();
+
+        appender.append(event);
+
+        verify(outputStreamDelegate, timeout(VERIFICATION_TIMEOUT)).doAppend(event);
+        verify(outputStream,         timeout(VERIFICATION_TIMEOUT)).flush();
+    }
+
+
+    /*
+     * OutputStreamAppender may return a null OutputStream 
+     */
+    @Test
+    public void flushWithNullOutputStream() {
+        when(outputStreamDelegate.getOutputStream()).thenReturn(null);
+
+        appender.addAppender(outputStreamDelegate);
+        appender.start();
+
+        appender.doAppend(event);
+
+        assertThat(appender.getStatusManager().getCount()).isZero();
+    }
+
+
+    /*
+     * Don't flush OutputStreamAppender at end of batch when they are configured 
+     * to "immediate flush"
+     */
+    @Test
+    public void notFlushedWhenImmediateFlush() throws Exception {
+        outputStreamDelegate.setImmediateFlush(true);
+        outputStreamDelegate.setOutputStream(new ByteArrayOutputStream()); // use a real output stream for the appender to flush itself
+
+        appender.addAppender(outputStreamDelegate);
+        appender.start();
+
+        appender.append(event);
+
+        verify(outputStreamDelegate, timeout(VERIFICATION_TIMEOUT)).doAppend(event);
         verify(outputStream, never()).flush();
     }
 
+
+    /*
+     * Flush appenders implementing "Flushable" at end of batch
+     */
+    @Test
+    public void flushFlushable() throws Exception {
+        FlushableAppender flushableDelegate = spy(new FlushableAppender());
+        
+        appender.addAppender(flushableDelegate);
+        appender.start();
+        
+        appender.append(event);
+        
+        verify(flushableDelegate, timeout(VERIFICATION_TIMEOUT)).doAppend(event);
+        verify(flushableDelegate).flush();
+    }
+
+
+    /*
+     * Don't flush stopped appenders
+     */
+    @Test
+    public void notFlushedWhenStopped() throws Exception {
+        appender.addAppender(outputStreamDelegate);
+        appender.start();
+
+        outputStreamDelegate.stop();
+
+        appender.append(event);
+
+        verify(outputStreamDelegate, timeout(VERIFICATION_TIMEOUT)).doAppend(event);
+        verify(outputStream, never()).flush();
+    }
+
+
+    /*
+     * Assert flush is called on all delegates even after one throws an exception
+     */
+    @Test
+    public void flushThrowsIOException() throws Exception {
+        IOException exception = new IOException("boum");
+        doThrow(exception).when(outputStream).flush();
+
+        FlushableAppender flushableDelegate = spy(new FlushableAppender());
+
+
+        appender.addAppender(outputStreamDelegate); // throws exception when flushed
+        appender.addAppender(flushableDelegate);
+        appender.start();
+
+        appender.append(event);
+
+        verify(outputStreamDelegate, timeout(VERIFICATION_TIMEOUT)).doAppend(event);
+
+        verify(flushableDelegate, timeout(VERIFICATION_TIMEOUT)).doAppend(event);
+        verify(flushableDelegate, timeout(VERIFICATION_TIMEOUT)).flush();
+    }
+
+
+    private static class TestAppender<E> extends AppenderBase<E> {
+        public TestAppender() {
+            super();
+        }
+        protected void append(E eventObject) {
+        }
+    }
+
+    private static class FlushableAppender extends TestAppender<ILoggingEvent> implements Flushable {
+        @Override
+        public void flush() throws IOException {
+        }
+    }
 }

--- a/src/test/java/net/logstash/logback/appender/DelegatingAsyncDisruptorAppenderTest.java
+++ b/src/test/java/net/logstash/logback/appender/DelegatingAsyncDisruptorAppenderTest.java
@@ -22,7 +22,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayOutputStream;
 import java.io.Flushable;
@@ -34,7 +33,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InOrder;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -53,7 +51,6 @@ public class DelegatingAsyncDisruptorAppenderTest {
 
     private static final int VERIFICATION_TIMEOUT = 1000 * 30;
 
-    @InjectMocks
     private DelegatingAsyncDisruptorAppender<ILoggingEvent, AppenderListener<ILoggingEvent>> appender = new DelegatingAsyncDisruptorAppender<ILoggingEvent, AppenderListener<ILoggingEvent>>() {};
 
     @Mock
@@ -210,11 +207,10 @@ public class DelegatingAsyncDisruptorAppenderTest {
      */
     @Test
     public void flushWithNullOutputStream() {
-        when(outputStreamDelegate.getOutputStream()).thenReturn(null);
-
         appender.addAppender(outputStreamDelegate);
         appender.start();
 
+        outputStreamDelegate.setOutputStream(null);
         appender.doAppend(event);
 
         assertThat(appender.getStatusManager().getCount()).isZero();


### PR DESCRIPTION
This PR addresses the following issues:

- Wrap calls to appenders within a try/catch block and make sure exceptions thrown by one does not prevent other appenders from receiving the event (#456).
- Flush appenders at end of batch only if they are started (#456).
- OutputStreamAppender may occasionally return a null OutputStream (#455)
- Flush appenders implementing java.io.Flushable (#454)