### PR TITLE
Configure M2E to ignore executions of the maven-license-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -384,6 +384,34 @@
                         </links>
                     </configuration>
                 </plugin>
+                
+                <!-- This plugin's configuration is used to store Eclipse m2e settings only. 
+                     It has no influence on the Maven build itself.
+                -->
+                <plugin>
+                    <groupId>org.eclipse.m2e</groupId>
+                    <artifactId>lifecycle-mapping</artifactId>
+                    <version>1.0.0</version>
+                    <configuration>
+                        <lifecycleMappingMetadata>
+                            <pluginExecutions>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>com.mycila.maven-license-plugin</groupId>
+                                        <artifactId>maven-license-plugin</artifactId>
+                                        <versionRange>[1.9.0,)</versionRange>
+                                        <goals>
+                                            <goal>format</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore></ignore>
+                                    </action>
+                                </pluginExecution>
+                            </pluginExecutions>
+                        </lifecycleMappingMetadata>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
Use the `org.eclipse.m2e:lifecycle-mapping` plugin to configure M2E to ignore execution of the `maven-license-plugin`.
Related issue: #468 