### PR TITLE
README maven logger should be runtime, not compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,12 +77,14 @@ Maven style:
     <groupId>net.logstash.logback</groupId>
     <artifactId>logstash-logback-encoder</artifactId>
     <version>6.6</version>
+    <scope>runtime</scope>
 </dependency>
 <!-- Your project must also directly depend on either logback-classic or logback-access.  For example: -->
 <dependency>
     <groupId>ch.qos.logback</groupId>
     <artifactId>logback-classic</artifactId>
     <version>1.2.3</version>
+    <scope>runtime</scope>
 </dependency>
 ```
 


### PR DESCRIPTION
should be runtime, not compile dependencies.