### PR TITLE
Avoid calling 'toArray' with pre-sized array argument

### DIFF
--- a/src/main/java/net/logstash/logback/appender/AbstractLogstashTcpSocketAppender.java
+++ b/src/main/java/net/logstash/logback/appender/AbstractLogstashTcpSocketAppender.java
@@ -1106,7 +1106,7 @@ public abstract class AbstractLogstashTcpSocketAppender<Event extends DeferredPr
 
         List<InetSocketAddress> parsedDestinations = DestinationParser.parse(destination, DEFAULT_PORT);
 
-        addDestinations(parsedDestinations.toArray(new InetSocketAddress[parsedDestinations.size()]));
+        addDestinations(parsedDestinations.toArray(new InetSocketAddress[0]));
     }
 
     /**

--- a/src/main/java/net/logstash/logback/appender/AsyncDisruptorAppender.java
+++ b/src/main/java/net/logstash/logback/appender/AsyncDisruptorAppender.java
@@ -474,7 +474,7 @@ public abstract class AsyncDisruptorAppender<Event extends DeferredProcessingAwa
 
     protected String calculateThreadName() {
         List<Object> threadNameFormatParams = getThreadNameFormatParams();
-        return String.format(threadNameFormat, threadNameFormatParams.toArray(new Object[threadNameFormatParams.size()]));
+        return String.format(threadNameFormat, threadNameFormatParams.toArray(new Object[0]));
     }
 
     protected List<Object> getThreadNameFormatParams() {

--- a/src/main/java/net/logstash/logback/appender/AsyncDisruptorAppender.java
+++ b/src/main/java/net/logstash/logback/appender/AsyncDisruptorAppender.java
@@ -474,7 +474,7 @@ public abstract class AsyncDisruptorAppender<Event extends DeferredProcessingAwa
 
     protected String calculateThreadName() {
         List<Object> threadNameFormatParams = getThreadNameFormatParams();
-        return String.format(threadNameFormat, threadNameFormatParams.toArray(new Object[0]));
+        return String.format(threadNameFormat, threadNameFormatParams.toArray());
     }
 
     protected List<Object> getThreadNameFormatParams() {


### PR DESCRIPTION
### Description

empty-array is recommended in modern java
```java
Object[] objArray = collection.toArray(new Object[0]);
```

#### Reference
- **intellij** insepction
>There are two styles to convert a collection to an array: either using a pre-sized array (like c.toArray(new String[c.size()])) or using an empty array (like c.toArray(new String[0]).
In older Java versions using pre-sized array was recommended, as the reflection call which is necessary to create an array of proper size was quite slow. However since late updates of OpenJDK 6 this call was intrinsified, making the performance of the empty array version the same and sometimes even better, compared to the pre-sized version. Also passing pre-sized array is dangerous for a concurrent or synchronized collection as a data race is possible between the size and toArray call which may result in extra nulls at the end of the array, if the collection was concurrently shrunk during the operation.
This inspection allows to follow the uniform style: either using an empty array (which is recommended in modern Java) or using a pre-sized array (which might be faster in older Java versions or non-HotSpot based JVMs).

#### Researches
~~~
https://shipilev.net/blog/2016/arrays-wisdom-ancients/#_new_reflective_array
https://code.i-harness.com/en/q/2a80d
~~~