### PR TITLE
Fix marker aggregation when multiple empty markers are aggregated.

### DIFF
--- a/src/main/java/net/logstash/logback/marker/LogstashBasicMarker.java
+++ b/src/main/java/net/logstash/logback/marker/LogstashBasicMarker.java
@@ -20,10 +20,10 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Vector;
 
-/* Copy of {@link org.slf4j.helpers.BasicMarker} from slf4j-api v1.7.12,
- * with a minor change to make the constructor public,
- * so that it can be extended in other packages.
- * <p>
+/* Copy of {@link org.slf4j.helpers.BasicMarker} from slf4j-api v1.7.12, with minor changes:
+ * 1. make the constructor public so that it can be extended in other packages
+ * 2. add getReferences() method
+
  * slf4j-api, {@link org.slf4j.helpers.BasicMarker}, and the portions
  * of this class that have been copied from BasicMarker are provided under
  * the MIT License copied here:
@@ -118,6 +118,18 @@ public class LogstashBasicMarker implements Marker {
             return Collections.emptyIterator();
         }
     }
+
+    /*
+     * BEGIN Modification in logstash-logback-encoder to add this method
+     */
+    protected List<Marker> getReferences() {
+        return refereceList == null
+                ? Collections.emptyList()
+                : Collections.unmodifiableList(refereceList);
+    }
+    /*
+     * END Modification in logstash-logback-encoder to add this method
+     */
 
     public synchronized boolean remove(Marker referenceToRemove) {
         if (refereceList == null) {

--- a/src/main/java/net/logstash/logback/marker/LogstashMarker.java
+++ b/src/main/java/net/logstash/logback/marker/LogstashMarker.java
@@ -14,6 +14,7 @@
 package net.logstash.logback.marker;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import org.slf4j.Marker;
 
@@ -75,6 +76,42 @@ public abstract class LogstashMarker extends LogstashBasicMarker implements Iter
      * @throws IOException if there was an error writing to the generator
      */
     public abstract void writeTo(JsonGenerator generator) throws IOException;
+
+    @Override
+    public synchronized void add(Marker reference) {
+        if (reference instanceof EmptyLogstashMarker) {
+            for (Marker m : (EmptyLogstashMarker) reference) {
+                add(m);
+            }
+        } else {
+            super.add(reference);
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + super.hashCode();
+        result = prime * result + this.getReferences().hashCode();
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!super.equals(obj)) {
+            return false;
+        }
+        if (!(obj instanceof LogstashMarker)) {
+            return false;
+        }
+
+        LogstashMarker other = (LogstashMarker) obj;
+        return Objects.equals(this.getReferences(), other.getReferences());
+    }
 
     /**
      * Returns a String in the form of

--- a/src/main/java/net/logstash/logback/marker/MapEntriesAppendingMarker.java
+++ b/src/main/java/net/logstash/logback/marker/MapEntriesAppendingMarker.java
@@ -101,6 +101,9 @@ public class MapEntriesAppendingMarker extends LogstashMarker implements Structu
 
     @Override
     public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
         if (!super.equals(obj)) {
             return false;
         }

--- a/src/main/java/net/logstash/logback/marker/ObjectAppendingMarker.java
+++ b/src/main/java/net/logstash/logback/marker/ObjectAppendingMarker.java
@@ -101,6 +101,9 @@ public class ObjectAppendingMarker extends SingleFieldAppendingMarker {
 
     @Override
     public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
         if (!super.equals(obj)) {
             return false;
         }

--- a/src/main/java/net/logstash/logback/marker/ObjectFieldsAppendingMarker.java
+++ b/src/main/java/net/logstash/logback/marker/ObjectFieldsAppendingMarker.java
@@ -167,6 +167,9 @@ public class ObjectFieldsAppendingMarker extends LogstashMarker implements Struc
 
     @Override
     public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
         if (!super.equals(obj)) {
             return false;
         }

--- a/src/main/java/net/logstash/logback/marker/RawJsonAppendingMarker.java
+++ b/src/main/java/net/logstash/logback/marker/RawJsonAppendingMarker.java
@@ -72,6 +72,9 @@ public class RawJsonAppendingMarker extends SingleFieldAppendingMarker {
 
     @Override
     public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
         if (!super.equals(obj)) {
             return false;
         }

--- a/src/main/java/net/logstash/logback/marker/SingleFieldAppendingMarker.java
+++ b/src/main/java/net/logstash/logback/marker/SingleFieldAppendingMarker.java
@@ -124,6 +124,9 @@ public abstract class SingleFieldAppendingMarker extends LogstashMarker implemen
 
     @Override
     public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
         if (!super.equals(obj)) {
             return false;
         }

--- a/src/test/java/net/logstash/logback/marker/MarkersTest.java
+++ b/src/test/java/net/logstash/logback/marker/MarkersTest.java
@@ -35,6 +35,21 @@ public class MarkersTest {
     }
 
     @Test
+    public void aggregate_multi() {
+        LogstashMarker marker1 = Markers.append("fieldName1", "fieldValue1");
+        LogstashMarker marker2 = Markers.append("fieldName2", "fieldValue2");
+        LogstashMarker aggregate = Markers.aggregate(marker1, marker2);
+
+        LogstashMarker marker3 = Markers.append("fieldName3", "fieldValue3");
+        aggregate = Markers.aggregate(aggregate, marker3);
+
+        assertThat(aggregate).isInstanceOf(EmptyLogstashMarker.class);
+        assertThat(aggregate.contains(marker1)).isTrue();
+        assertThat(aggregate.contains(marker2)).isTrue();
+        assertThat(aggregate.contains(marker3)).isTrue();
+    }
+
+    @Test
     public void testToString() {
 
         assertThat(Markers.empty().toString())


### PR DESCRIPTION
Previously, if multiple empty markers with references were aggregated, only one marker would be be returned as the aggregate (and the other's references would be lost).

Fixes #527