### PR TITLE
Remove JsonFactoryDecorator.decorate(MappingJsonFactory)

### DIFF
--- a/src/main/java/net/logstash/logback/decorate/CharacterEscapesJsonFactoryDecorator.java
+++ b/src/main/java/net/logstash/logback/decorate/CharacterEscapesJsonFactoryDecorator.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.SerializableString;
 import com.fasterxml.jackson.core.io.CharacterEscapes;
 import com.fasterxml.jackson.core.io.SerializedString;
-import com.fasterxml.jackson.databind.MappingJsonFactory;
 
 /**
  * A {@link JsonFactoryDecorator} that can be used to customize the {@link JsonFactory#setCharacterEscapes(CharacterEscapes)}.
@@ -240,12 +239,6 @@ public class CharacterEscapesJsonFactoryDecorator implements JsonFactoryDecorato
      * A {@link CharacterEscapes} implementation that has been created from the registered {@link CharacterEscapesJsonFactoryDecorator#escapes}
      */
     private CustomizedCharacterEscapes characterEscapes;
-
-    @Override
-    @Deprecated
-    public MappingJsonFactory decorate(MappingJsonFactory factory) {
-        return (MappingJsonFactory) decorate((JsonFactory) factory);
-    }
 
     @Override
     public JsonFactory decorate(JsonFactory factory) {

--- a/src/main/java/net/logstash/logback/decorate/CompositeJsonFactoryDecorator.java
+++ b/src/main/java/net/logstash/logback/decorate/CompositeJsonFactoryDecorator.java
@@ -17,7 +17,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.databind.MappingJsonFactory;
 
 /**
  * Combines a list of decorators into a single decorator, so multiple decorators can be used together.
@@ -25,12 +24,6 @@ import com.fasterxml.jackson.databind.MappingJsonFactory;
 public class CompositeJsonFactoryDecorator implements JsonFactoryDecorator {
     
     private final List<JsonFactoryDecorator> decorators = new ArrayList<JsonFactoryDecorator>();
-
-    @Override
-    @Deprecated
-    public MappingJsonFactory decorate(MappingJsonFactory factory) {
-        return (MappingJsonFactory) decorate((JsonFactory) factory);
-    }
 
     @Override
     public JsonFactory decorate(JsonFactory factory) {

--- a/src/main/java/net/logstash/logback/decorate/EscapeNonAsciiJsonFactoryDecorator.java
+++ b/src/main/java/net/logstash/logback/decorate/EscapeNonAsciiJsonFactoryDecorator.java
@@ -15,7 +15,6 @@ package net.logstash.logback.decorate;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.MappingJsonFactory;
 
 /**
  * Enables the {@link com.fasterxml.jackson.core.JsonGenerator.Feature#ESCAPE_NON_ASCII} feature on the {@link JsonFactory}.
@@ -24,12 +23,6 @@ import com.fasterxml.jackson.databind.MappingJsonFactory;
  * In 5.0, the feature is disabled by default, and can be re-enabled with this decorator.
  */
 public class EscapeNonAsciiJsonFactoryDecorator implements JsonFactoryDecorator {
-
-    @Override
-    @Deprecated
-    public MappingJsonFactory decorate(MappingJsonFactory factory) {
-        return (MappingJsonFactory) decorate((JsonFactory) factory);
-    }
 
     @Override
     public JsonFactory decorate(JsonFactory factory) {

--- a/src/main/java/net/logstash/logback/decorate/JsonFactoryDecorator.java
+++ b/src/main/java/net/logstash/logback/decorate/JsonFactoryDecorator.java
@@ -32,41 +32,18 @@ import com.fasterxml.jackson.databind.MappingJsonFactory;
 public interface JsonFactoryDecorator {
 
     /**
-     * Decorates the given {@link MappingJsonFactory}.
-     *
-     * By default, returns the given factory unchanged.
-     *
-     * @deprecated Override {@link #decorate(JsonFactory)} instead.
-     *             Will be removed in a future release.
-     *
-     * @return the decorated MappingJsonFactory
-     */
-    @Deprecated
-    default MappingJsonFactory decorate(MappingJsonFactory factory) {
-        return factory;
-    }
-
-    /**
      * Decorates the given {@link JsonFactory}.
      *
-     * By default, for backwards compatibility purposes,
-     * this assumes the given factory is a {@link MappingJsonFactory},
-     * and calls {@link #decorate(MappingJsonFactory)} so that existing
-     * implementations that only implemented {@link #decorate(MappingJsonFactory)} continue to work.
-     * In a future release, this will be changed to return the given factory by default,
-     * and {@link #decorate(MappingJsonFactory)} will be removed.
-     * It is recommended to only override {@link #decorate(JsonFactory)}.
-     * Existing implementations should migrate to only overriding {@link #decorate(JsonFactory)}
-     * so that they will continue to work after {@link #decorate(MappingJsonFactory)} is removed.
+     * <p>By default, returns the given factory unchanged.</p>
      *
-     * Note that the default {@link JsonFactory} created by logstash-logback-encoder
+     * <p>Note that the default {@link JsonFactory} created by logstash-logback-encoder
      * is a {@link MappingJsonFactory}, but can be changed by {@link JsonFactoryDecorator}s
-     * to any subclass of {@link JsonFactory}.
+     * to any subclass of {@link JsonFactory}.</p>
      *
      * @return the decorated {@link JsonFactory}
      */
     default JsonFactory decorate(JsonFactory factory) {
-        return decorate((MappingJsonFactory) factory);
+        return factory;
     }
 
 }


### PR DESCRIPTION
All implementations should override `JsonFactoryDecorator.decorate(JsonFactory)` instead

Part of #470 