### PR TITLE
Update to license-maven-plugin:4.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,8 +98,39 @@ Source Code Style
 -----------------
 
 Please follow the style used by the existing code in the repository.
-
 Rules are enforced by [checkstyle](src/checkstyle/checkstyle.xml).
+
+Java source files must include the following header at the top of the file, before the _package_ declaration:
+
+```
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+```
+
+The project makes use of the great https://github.com/mathieucarbou/license-maven-plugin[Mycila Maven License Plugin] to check for the presence of a valid header in source files during the build process.
+
+You can manually check your source files by invoking the plugin manually on the command line as follows:
+
+```
+mvn license:check
+```
+
+You can also ask the plugin to automatically update the header for you like this:
+
+```
+mvn license:format
+```
 
 
 License
@@ -107,3 +138,4 @@ License
 
 By contributing, you agree that the contributions will be licensed under the
 [Apache License 2.0](https://github.com/logstash/logstash-logback-encoder/blob/main/LICENSE).
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,7 +120,7 @@ Java source files must include the following header at the top of the file, befo
  */
 ```
 
-The project makes use of the great https://github.com/mathieucarbou/license-maven-plugin[Mycila Maven License Plugin] to check for the presence of a valid header in source files during the build process.
+The project makes use of the great [Mycila Maven License Plugin](https://github.com/mathieucarbou/license-maven-plugin) to check for the presence of a valid header in source files during the build process.
 
 You can manually check your source files by invoking the plugin manually on the command line as follows:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,7 +103,9 @@ Rules are enforced by [checkstyle](src/checkstyle/checkstyle.xml).
 Java source files must include the following header at the top of the file, before the _package_ declaration:
 
 ```
-/**
+/*
+ * Copyright 2013-${year} the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/license-header.txt
+++ b/license-header.txt
@@ -1,3 +1,5 @@
+Copyright 2013-${year} the original author or authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,7 @@
     <name>Logstash Logback Encoder</name>
     <description>Provides logback encoders, layouts, and appenders to log in JSON and other formats supported by Jackson</description>
     <url>https://github.com/logstash/logstash-logback-encoder</url>
+    <inceptionYear>2013</inceptionYear>
 
     <scm>
         <url>https://github.com/logstash/logstash-logback-encoder</url>
@@ -407,21 +408,24 @@
                     </dependencies>
                 </plugin>
                 
-	            <plugin>
-	                <groupId>com.mycila</groupId>
-	                <artifactId>license-maven-plugin</artifactId>
-	                <version>${license-maven-plugin.version}</version>
-	                <configuration>
-	                    <header>license-header.txt</header>
-						<mapping>
-							<java>JAVADOC_STYLE</java>
-						</mapping>
-	                    <includes>
-	                        <include>src/main/java/**</include>
-	                        <include>src/test/java/**</include>
-	                    </includes>
-	                </configuration>
-	            </plugin>
+                <plugin>
+                    <groupId>com.mycila</groupId>
+                    <artifactId>license-maven-plugin</artifactId>
+                    <version>${license-maven-plugin.version}</version>
+                    <configuration>
+                        <header>license-header.txt</header>
+                        <mapping>
+                            <java>SLASHSTAR_STYLE</java>
+                        </mapping>
+                        <includes>
+                            <include>src/main/java/**</include>
+                            <include>src/test/java/**</include>
+                        </includes>
+                        <defaultProperties>
+                            <year>2021</year>
+                        </defaultProperties>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,6 @@
 
         <!-- maven plugins -->
         <animal-sniffer-maven-plugin.version>1.20</animal-sniffer-maven-plugin.version>
-        <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
         <maven-bundle-plugin.version>5.1.2</maven-bundle-plugin.version>
         <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
@@ -44,7 +43,7 @@
         <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
         <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
         <maven-javadoc-plugin.version>3.3.0</maven-javadoc-plugin.version>
-        <maven-license-plugin.version>1.9.0</maven-license-plugin.version>
+        <license-maven-plugin.version>4.1</license-maven-plugin.version>
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
         <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
@@ -268,26 +267,13 @@
                 <version>${maven-release-plugin.version}</version>
             </plugin>
             <plugin>
-                <groupId>com.mycila.maven-license-plugin</groupId>
-                <artifactId>maven-license-plugin</artifactId>
-                <version>${maven-license-plugin.version}</version>
-                <configuration>
-                    <header>license-header.txt</header>
-                    <strictCheck>true</strictCheck>
-                    <aggregate>true</aggregate>
-                    <encoding>UTF-8</encoding>
-                    <failIfMissing>true</failIfMissing>
-                    <skipExistingHeaders>true</skipExistingHeaders>
-                    <includes>
-                        <include>**/src/main/java/**</include>
-                        <include>**/src/test/java/**</include>
-                    </includes>
-                </configuration>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
                 <executions>
                     <execution>
                         <phase>process-sources</phase>
                         <goals>
-                            <goal>format</goal>
+                            <goal>check</goal>
                         </goals>
                     </execution>
                 </executions>
@@ -421,33 +407,21 @@
                     </dependencies>
                 </plugin>
                 
-                <!-- This plugin's configuration is used to store Eclipse m2e settings only. 
-                     It has no influence on the Maven build itself.
-                -->
-                <plugin>
-                    <groupId>org.eclipse.m2e</groupId>
-                    <artifactId>lifecycle-mapping</artifactId>
-                    <version>${lifecycle-mapping.version}</version>
-                    <configuration>
-                        <lifecycleMappingMetadata>
-                            <pluginExecutions>
-                                <pluginExecution>
-                                    <pluginExecutionFilter>
-                                        <groupId>com.mycila.maven-license-plugin</groupId>
-                                        <artifactId>maven-license-plugin</artifactId>
-                                        <versionRange>[1.9.0,)</versionRange>
-                                        <goals>
-                                            <goal>format</goal>
-                                        </goals>
-                                    </pluginExecutionFilter>
-                                    <action>
-                                        <ignore></ignore>
-                                    </action>
-                                </pluginExecution>
-                            </pluginExecutions>
-                        </lifecycleMappingMetadata>
-                    </configuration>
-                </plugin>
+	            <plugin>
+	                <groupId>com.mycila</groupId>
+	                <artifactId>license-maven-plugin</artifactId>
+	                <version>${license-maven-plugin.version}</version>
+	                <configuration>
+	                    <header>license-header.txt</header>
+						<mapping>
+							<java>JAVADOC_STYLE</java>
+						</mapping>
+	                    <includes>
+	                        <include>src/main/java/**</include>
+	                        <include>src/test/java/**</include>
+	                    </includes>
+	                </configuration>
+	            </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
 
         <!-- maven plugins -->
         <animal-sniffer-maven-plugin.version>1.20</animal-sniffer-maven-plugin.version>
+        <license-maven-plugin.version>4.1</license-maven-plugin.version>
         <maven-bundle-plugin.version>5.1.2</maven-bundle-plugin.version>
         <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
@@ -44,7 +45,6 @@
         <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
         <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
         <maven-javadoc-plugin.version>3.3.0</maven-javadoc-plugin.version>
-        <license-maven-plugin.version>4.1</license-maven-plugin.version>
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
         <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>

--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -85,6 +85,6 @@
         <module name="UpperEll"/>
     </module>
     <module name="RegexpHeader">
-        <property name="header" value="^/\*\*\n^ \* Licensed under the Apache License, Version 2\.0 \(the &quot;License&quot;\);"/>
+        <property name="header" value="^/\*\n^ \* Copyright .* the original author or authors\.\n^ *\n^ \* Licensed under the Apache License, Version 2\.0 \(the &quot;License&quot;\);"/>
     </module>
 </module>

--- a/src/main/java/net/logstash/logback/CachingAbbreviator.java
+++ b/src/main/java/net/logstash/logback/CachingAbbreviator.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/LogstashAccessFormatter.java
+++ b/src/main/java/net/logstash/logback/LogstashAccessFormatter.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/LogstashFormatter.java
+++ b/src/main/java/net/logstash/logback/LogstashFormatter.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/NullAbbreviator.java
+++ b/src/main/java/net/logstash/logback/NullAbbreviator.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/appender/AbstractLogstashTcpSocketAppender.java
+++ b/src/main/java/net/logstash/logback/appender/AbstractLogstashTcpSocketAppender.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/appender/AbstractLogstashUdpSocketAppender.java
+++ b/src/main/java/net/logstash/logback/appender/AbstractLogstashUdpSocketAppender.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/appender/AccessEventAsyncDisruptorAppender.java
+++ b/src/main/java/net/logstash/logback/appender/AccessEventAsyncDisruptorAppender.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/appender/AsyncDisruptorAppender.java
+++ b/src/main/java/net/logstash/logback/appender/AsyncDisruptorAppender.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/appender/DelegatingAsyncDisruptorAppender.java
+++ b/src/main/java/net/logstash/logback/appender/DelegatingAsyncDisruptorAppender.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/appender/LoggingEventAsyncDisruptorAppender.java
+++ b/src/main/java/net/logstash/logback/appender/LoggingEventAsyncDisruptorAppender.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/appender/LogstashAccessTcpSocketAppender.java
+++ b/src/main/java/net/logstash/logback/appender/LogstashAccessTcpSocketAppender.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/appender/LogstashAccessUdpSocketAppender.java
+++ b/src/main/java/net/logstash/logback/appender/LogstashAccessUdpSocketAppender.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/appender/LogstashTcpSocketAppender.java
+++ b/src/main/java/net/logstash/logback/appender/LogstashTcpSocketAppender.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/appender/LogstashUdpSocketAppender.java
+++ b/src/main/java/net/logstash/logback/appender/LogstashUdpSocketAppender.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/appender/NotConnectedException.java
+++ b/src/main/java/net/logstash/logback/appender/NotConnectedException.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/appender/RingBufferFullException.java
+++ b/src/main/java/net/logstash/logback/appender/RingBufferFullException.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/appender/ShutdownInProgressException.java
+++ b/src/main/java/net/logstash/logback/appender/ShutdownInProgressException.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/appender/WaitStrategyFactory.java
+++ b/src/main/java/net/logstash/logback/appender/WaitStrategyFactory.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/appender/destination/DelegateDestinationConnectionStrategy.java
+++ b/src/main/java/net/logstash/logback/appender/destination/DelegateDestinationConnectionStrategy.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/appender/destination/DestinationConnectionStrategy.java
+++ b/src/main/java/net/logstash/logback/appender/destination/DestinationConnectionStrategy.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/appender/destination/DestinationConnectionStrategyWithTtl.java
+++ b/src/main/java/net/logstash/logback/appender/destination/DestinationConnectionStrategyWithTtl.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/appender/destination/DestinationParser.java
+++ b/src/main/java/net/logstash/logback/appender/destination/DestinationParser.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/appender/destination/PreferPrimaryDestinationConnectionStrategy.java
+++ b/src/main/java/net/logstash/logback/appender/destination/PreferPrimaryDestinationConnectionStrategy.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/appender/destination/RandomDestinationConnectionStrategy.java
+++ b/src/main/java/net/logstash/logback/appender/destination/RandomDestinationConnectionStrategy.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/appender/destination/RoundRobinDestinationConnectionStrategy.java
+++ b/src/main/java/net/logstash/logback/appender/destination/RoundRobinDestinationConnectionStrategy.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/appender/listener/AccessEventAppenderListenerImpl.java
+++ b/src/main/java/net/logstash/logback/appender/listener/AccessEventAppenderListenerImpl.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/appender/listener/AccessEventTcpAppenderListenerImpl.java
+++ b/src/main/java/net/logstash/logback/appender/listener/AccessEventTcpAppenderListenerImpl.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/appender/listener/AppenderListener.java
+++ b/src/main/java/net/logstash/logback/appender/listener/AppenderListener.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/appender/listener/FailureSummaryAppenderListener.java
+++ b/src/main/java/net/logstash/logback/appender/listener/FailureSummaryAppenderListener.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/appender/listener/FailureSummaryLoggingAppenderListener.java
+++ b/src/main/java/net/logstash/logback/appender/listener/FailureSummaryLoggingAppenderListener.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/appender/listener/LoggingEventAppenderListenerImpl.java
+++ b/src/main/java/net/logstash/logback/appender/listener/LoggingEventAppenderListenerImpl.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/appender/listener/LoggingEventTcpAppenderListenerImpl.java
+++ b/src/main/java/net/logstash/logback/appender/listener/LoggingEventTcpAppenderListenerImpl.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/appender/listener/TcpAppenderListener.java
+++ b/src/main/java/net/logstash/logback/appender/listener/TcpAppenderListener.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/argument/DeferredStructuredArgument.java
+++ b/src/main/java/net/logstash/logback/argument/DeferredStructuredArgument.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/argument/StructuredArgument.java
+++ b/src/main/java/net/logstash/logback/argument/StructuredArgument.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/argument/StructuredArguments.java
+++ b/src/main/java/net/logstash/logback/argument/StructuredArguments.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/AbstractFieldJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/AbstractFieldJsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/AbstractJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/AbstractJsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/AbstractNestedJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/AbstractNestedJsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/AbstractPatternJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/AbstractPatternJsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/CompositeJsonFormatter.java
+++ b/src/main/java/net/logstash/logback/composite/CompositeJsonFormatter.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/ContextJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/ContextJsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/FieldNamesAware.java
+++ b/src/main/java/net/logstash/logback/composite/FieldNamesAware.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/FormattedTimestampJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/FormattedTimestampJsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/GlobalCustomFieldsJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/GlobalCustomFieldsJsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/JsonFactoryAware.java
+++ b/src/main/java/net/logstash/logback/composite/JsonFactoryAware.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/JsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/JsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/JsonProviders.java
+++ b/src/main/java/net/logstash/logback/composite/JsonProviders.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/JsonWritingUtils.java
+++ b/src/main/java/net/logstash/logback/composite/JsonWritingUtils.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/LogstashVersionJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/LogstashVersionJsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/accessevent/AccessEventCompositeJsonFormatter.java
+++ b/src/main/java/net/logstash/logback/composite/accessevent/AccessEventCompositeJsonFormatter.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/accessevent/AccessEventFormattedTimestampJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/accessevent/AccessEventFormattedTimestampJsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/accessevent/AccessEventJsonProviders.java
+++ b/src/main/java/net/logstash/logback/composite/accessevent/AccessEventJsonProviders.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/accessevent/AccessEventNestedJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/accessevent/AccessEventNestedJsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/accessevent/AccessEventPatternJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/accessevent/AccessEventPatternJsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/accessevent/AccessMessageJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/accessevent/AccessMessageJsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/accessevent/ContentLengthJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/accessevent/ContentLengthJsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/accessevent/ElapsedTimeJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/accessevent/ElapsedTimeJsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/accessevent/HeaderFilter.java
+++ b/src/main/java/net/logstash/logback/composite/accessevent/HeaderFilter.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/accessevent/IncludeExcludeHeaderFilter.java
+++ b/src/main/java/net/logstash/logback/composite/accessevent/IncludeExcludeHeaderFilter.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/accessevent/MethodJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/accessevent/MethodJsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/accessevent/ProtocolJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/accessevent/ProtocolJsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/accessevent/RemoteHostJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/accessevent/RemoteHostJsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/accessevent/RemoteUserJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/accessevent/RemoteUserJsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/accessevent/RequestHeadersJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/accessevent/RequestHeadersJsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/accessevent/RequestedUriJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/accessevent/RequestedUriJsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/accessevent/RequestedUrlJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/accessevent/RequestedUrlJsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/accessevent/ResponseHeadersJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/accessevent/ResponseHeadersJsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/accessevent/StatusCodeJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/accessevent/StatusCodeJsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/loggingevent/AbstractThrowableClassNameJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/loggingevent/AbstractThrowableClassNameJsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/loggingevent/ArgumentsJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/loggingevent/ArgumentsJsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/loggingevent/CallerDataJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/loggingevent/CallerDataJsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/loggingevent/ContextNameJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/loggingevent/ContextNameJsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/loggingevent/LogLevelJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/loggingevent/LogLevelJsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/loggingevent/LogLevelValueJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/loggingevent/LogLevelValueJsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/loggingevent/LoggerNameJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/loggingevent/LoggerNameJsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/loggingevent/LoggingEventCompositeJsonFormatter.java
+++ b/src/main/java/net/logstash/logback/composite/loggingevent/LoggingEventCompositeJsonFormatter.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/loggingevent/LoggingEventFormattedTimestampJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/loggingevent/LoggingEventFormattedTimestampJsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/loggingevent/LoggingEventJsonProviders.java
+++ b/src/main/java/net/logstash/logback/composite/loggingevent/LoggingEventJsonProviders.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/loggingevent/LoggingEventNestedJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/loggingevent/LoggingEventNestedJsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/loggingevent/LoggingEventPatternJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/loggingevent/LoggingEventPatternJsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/loggingevent/LogstashMarkersJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/loggingevent/LogstashMarkersJsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/loggingevent/MdcJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/loggingevent/MdcJsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/loggingevent/MessageJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/loggingevent/MessageJsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/loggingevent/RawMessageJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/loggingevent/RawMessageJsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/loggingevent/RootStackTraceElementJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/loggingevent/RootStackTraceElementJsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/loggingevent/SequenceJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/loggingevent/SequenceJsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/loggingevent/StackHashJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/loggingevent/StackHashJsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/loggingevent/StackTraceJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/loggingevent/StackTraceJsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/loggingevent/TagsJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/loggingevent/TagsJsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/loggingevent/ThreadNameJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/loggingevent/ThreadNameJsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/loggingevent/ThrowableClassNameJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/loggingevent/ThrowableClassNameJsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/loggingevent/ThrowableRootCauseClassNameJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/loggingevent/ThrowableRootCauseClassNameJsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/composite/loggingevent/UuidProvider.java
+++ b/src/main/java/net/logstash/logback/composite/loggingevent/UuidProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/decorate/CharacterEscapesJsonFactoryDecorator.java
+++ b/src/main/java/net/logstash/logback/decorate/CharacterEscapesJsonFactoryDecorator.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/decorate/CompositeJsonFactoryDecorator.java
+++ b/src/main/java/net/logstash/logback/decorate/CompositeJsonFactoryDecorator.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/decorate/CompositeJsonGeneratorDecorator.java
+++ b/src/main/java/net/logstash/logback/decorate/CompositeJsonGeneratorDecorator.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/decorate/EscapeNonAsciiJsonFactoryDecorator.java
+++ b/src/main/java/net/logstash/logback/decorate/EscapeNonAsciiJsonFactoryDecorator.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/decorate/FeatureDecorator.java
+++ b/src/main/java/net/logstash/logback/decorate/FeatureDecorator.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/decorate/FeatureJsonFactoryDecorator.java
+++ b/src/main/java/net/logstash/logback/decorate/FeatureJsonFactoryDecorator.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/decorate/FeatureJsonGeneratorDecorator.java
+++ b/src/main/java/net/logstash/logback/decorate/FeatureJsonGeneratorDecorator.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/decorate/JsonFactoryDecorator.java
+++ b/src/main/java/net/logstash/logback/decorate/JsonFactoryDecorator.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/decorate/JsonGeneratorDecorator.java
+++ b/src/main/java/net/logstash/logback/decorate/JsonGeneratorDecorator.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/decorate/NullJsonFactoryDecorator.java
+++ b/src/main/java/net/logstash/logback/decorate/NullJsonFactoryDecorator.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/decorate/NullJsonGeneratorDecorator.java
+++ b/src/main/java/net/logstash/logback/decorate/NullJsonGeneratorDecorator.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/decorate/PrettyPrintingJsonGeneratorDecorator.java
+++ b/src/main/java/net/logstash/logback/decorate/PrettyPrintingJsonGeneratorDecorator.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/decorate/cbor/CborFeatureJsonGeneratorDecorator.java
+++ b/src/main/java/net/logstash/logback/decorate/cbor/CborFeatureJsonGeneratorDecorator.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/decorate/cbor/CborJsonFactoryDecorator.java
+++ b/src/main/java/net/logstash/logback/decorate/cbor/CborJsonFactoryDecorator.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/decorate/smile/SmileFeatureJsonGeneratorDecorator.java
+++ b/src/main/java/net/logstash/logback/decorate/smile/SmileFeatureJsonGeneratorDecorator.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/decorate/smile/SmileJsonFactoryDecorator.java
+++ b/src/main/java/net/logstash/logback/decorate/smile/SmileJsonFactoryDecorator.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/decorate/yaml/YamlFeatureJsonGeneratorDecorator.java
+++ b/src/main/java/net/logstash/logback/decorate/yaml/YamlFeatureJsonGeneratorDecorator.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/decorate/yaml/YamlJsonFactoryDecorator.java
+++ b/src/main/java/net/logstash/logback/decorate/yaml/YamlJsonFactoryDecorator.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/encoder/AccessEventCompositeJsonEncoder.java
+++ b/src/main/java/net/logstash/logback/encoder/AccessEventCompositeJsonEncoder.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/encoder/CompositeJsonEncoder.java
+++ b/src/main/java/net/logstash/logback/encoder/CompositeJsonEncoder.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/encoder/LoggingEventCompositeJsonEncoder.java
+++ b/src/main/java/net/logstash/logback/encoder/LoggingEventCompositeJsonEncoder.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/encoder/LogstashAccessEncoder.java
+++ b/src/main/java/net/logstash/logback/encoder/LogstashAccessEncoder.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/encoder/LogstashEncoder.java
+++ b/src/main/java/net/logstash/logback/encoder/LogstashEncoder.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/encoder/SeparatorParser.java
+++ b/src/main/java/net/logstash/logback/encoder/SeparatorParser.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/encoder/StreamingEncoder.java
+++ b/src/main/java/net/logstash/logback/encoder/StreamingEncoder.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/fieldnames/LogstashAccessFieldNames.java
+++ b/src/main/java/net/logstash/logback/fieldnames/LogstashAccessFieldNames.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/fieldnames/LogstashCommonFieldNames.java
+++ b/src/main/java/net/logstash/logback/fieldnames/LogstashCommonFieldNames.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/fieldnames/LogstashFieldNames.java
+++ b/src/main/java/net/logstash/logback/fieldnames/LogstashFieldNames.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/fieldnames/Pre50LogstashAccessFieldNames.java
+++ b/src/main/java/net/logstash/logback/fieldnames/Pre50LogstashAccessFieldNames.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/fieldnames/ShortenedFieldNames.java
+++ b/src/main/java/net/logstash/logback/fieldnames/ShortenedFieldNames.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/layout/AccessEventCompositeJsonLayout.java
+++ b/src/main/java/net/logstash/logback/layout/AccessEventCompositeJsonLayout.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/layout/CompositeJsonLayout.java
+++ b/src/main/java/net/logstash/logback/layout/CompositeJsonLayout.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/layout/LoggingEventCompositeJsonLayout.java
+++ b/src/main/java/net/logstash/logback/layout/LoggingEventCompositeJsonLayout.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/layout/LogstashAccessLayout.java
+++ b/src/main/java/net/logstash/logback/layout/LogstashAccessLayout.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/layout/LogstashLayout.java
+++ b/src/main/java/net/logstash/logback/layout/LogstashLayout.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/marker/DeferredLogstashMarker.java
+++ b/src/main/java/net/logstash/logback/marker/DeferredLogstashMarker.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/marker/EmptyLogstashMarker.java
+++ b/src/main/java/net/logstash/logback/marker/EmptyLogstashMarker.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/marker/LogstashBasicMarker.java
+++ b/src/main/java/net/logstash/logback/marker/LogstashBasicMarker.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/marker/LogstashMarker.java
+++ b/src/main/java/net/logstash/logback/marker/LogstashMarker.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/marker/MapEntriesAppendingMarker.java
+++ b/src/main/java/net/logstash/logback/marker/MapEntriesAppendingMarker.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/marker/Markers.java
+++ b/src/main/java/net/logstash/logback/marker/Markers.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/marker/MessageFormatCache.java
+++ b/src/main/java/net/logstash/logback/marker/MessageFormatCache.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/marker/ObjectAppendingMarker.java
+++ b/src/main/java/net/logstash/logback/marker/ObjectAppendingMarker.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/marker/ObjectFieldsAppendingMarker.java
+++ b/src/main/java/net/logstash/logback/marker/ObjectFieldsAppendingMarker.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/marker/RawJsonAppendingMarker.java
+++ b/src/main/java/net/logstash/logback/marker/RawJsonAppendingMarker.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/marker/SingleFieldAppendingMarker.java
+++ b/src/main/java/net/logstash/logback/marker/SingleFieldAppendingMarker.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/mask/FieldMasker.java
+++ b/src/main/java/net/logstash/logback/mask/FieldMasker.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/mask/FieldNameBasedFieldMasker.java
+++ b/src/main/java/net/logstash/logback/mask/FieldNameBasedFieldMasker.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/mask/MaskingJsonGenerator.java
+++ b/src/main/java/net/logstash/logback/mask/MaskingJsonGenerator.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/mask/MaskingJsonGeneratorDecorator.java
+++ b/src/main/java/net/logstash/logback/mask/MaskingJsonGeneratorDecorator.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/mask/PathBasedFieldMasker.java
+++ b/src/main/java/net/logstash/logback/mask/PathBasedFieldMasker.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/mask/RegexValueMasker.java
+++ b/src/main/java/net/logstash/logback/mask/RegexValueMasker.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/mask/ValueMasker.java
+++ b/src/main/java/net/logstash/logback/mask/ValueMasker.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/pattern/AbstractJsonPatternParser.java
+++ b/src/main/java/net/logstash/logback/pattern/AbstractJsonPatternParser.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/pattern/AccessEventJsonPatternParser.java
+++ b/src/main/java/net/logstash/logback/pattern/AccessEventJsonPatternParser.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/pattern/LoggingEventJsonPatternParser.java
+++ b/src/main/java/net/logstash/logback/pattern/LoggingEventJsonPatternParser.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/pattern/NodeWriter.java
+++ b/src/main/java/net/logstash/logback/pattern/NodeWriter.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/pattern/ValueGetter.java
+++ b/src/main/java/net/logstash/logback/pattern/ValueGetter.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/stacktrace/ShortenedThrowableConverter.java
+++ b/src/main/java/net/logstash/logback/stacktrace/ShortenedThrowableConverter.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/stacktrace/StackElementFilter.java
+++ b/src/main/java/net/logstash/logback/stacktrace/StackElementFilter.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/stacktrace/StackHasher.java
+++ b/src/main/java/net/logstash/logback/stacktrace/StackHasher.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/status/DelegatingStatusListener.java
+++ b/src/main/java/net/logstash/logback/status/DelegatingStatusListener.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/status/LevelFilteringStatusListener.java
+++ b/src/main/java/net/logstash/logback/status/LevelFilteringStatusListener.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/util/ReusableByteBuffer.java
+++ b/src/main/java/net/logstash/logback/util/ReusableByteBuffer.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/logstash/logback/util/ReusableByteBufferPool.java
+++ b/src/main/java/net/logstash/logback/util/ReusableByteBufferPool.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/ConfigurationTest.java
+++ b/src/test/java/net/logstash/logback/ConfigurationTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/TestJsonProvider.java
+++ b/src/test/java/net/logstash/logback/TestJsonProvider.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/appender/AsyncDisruptorAppenderTest.java
+++ b/src/test/java/net/logstash/logback/appender/AsyncDisruptorAppenderTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/appender/CachingAbbreviatorTest.java
+++ b/src/test/java/net/logstash/logback/appender/CachingAbbreviatorTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/appender/DelegatingAsyncDisruptorAppenderTest.java
+++ b/src/test/java/net/logstash/logback/appender/DelegatingAsyncDisruptorAppenderTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/appender/LogstashTcpSocketAppenderTest.java
+++ b/src/test/java/net/logstash/logback/appender/LogstashTcpSocketAppenderTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/appender/WaitStrategyFactoryTest.java
+++ b/src/test/java/net/logstash/logback/appender/WaitStrategyFactoryTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/appender/destination/DestinationParserTest.java
+++ b/src/test/java/net/logstash/logback/appender/destination/DestinationParserTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/appender/destination/PreferPrimaryDestinationConnectionStrategyTest.java
+++ b/src/test/java/net/logstash/logback/appender/destination/PreferPrimaryDestinationConnectionStrategyTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/appender/destination/RandomDestinationConnectionStrategyTest.java
+++ b/src/test/java/net/logstash/logback/appender/destination/RandomDestinationConnectionStrategyTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/appender/destination/RoundRobinDestinationConnectionStrategyTest.java
+++ b/src/test/java/net/logstash/logback/appender/destination/RoundRobinDestinationConnectionStrategyTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/appender/listener/FailureSummaryLoggingAppenderListenerTest.java
+++ b/src/test/java/net/logstash/logback/appender/listener/FailureSummaryLoggingAppenderListenerTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/argument/DeferredStructuredArgumentTest.java
+++ b/src/test/java/net/logstash/logback/argument/DeferredStructuredArgumentTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/argument/StructuredArgumentsToStringTest.java
+++ b/src/test/java/net/logstash/logback/argument/StructuredArgumentsToStringTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/composite/AbstractPatternJsonProviderTest.java
+++ b/src/test/java/net/logstash/logback/composite/AbstractPatternJsonProviderTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/composite/GlobalCustomFieldsJsonProviderTest.java
+++ b/src/test/java/net/logstash/logback/composite/GlobalCustomFieldsJsonProviderTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/composite/LogstashVersionJsonProviderTest.java
+++ b/src/test/java/net/logstash/logback/composite/LogstashVersionJsonProviderTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/composite/accessevent/AccessEventNestedJsonProviderTest.java
+++ b/src/test/java/net/logstash/logback/composite/accessevent/AccessEventNestedJsonProviderTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/composite/accessevent/AccessEventPatternJsonProviderTest.java
+++ b/src/test/java/net/logstash/logback/composite/accessevent/AccessEventPatternJsonProviderTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/composite/accessevent/IncludeExcludeHeaderFilterTest.java
+++ b/src/test/java/net/logstash/logback/composite/accessevent/IncludeExcludeHeaderFilterTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/composite/accessevent/RequestHeadersJsonProviderTest.java
+++ b/src/test/java/net/logstash/logback/composite/accessevent/RequestHeadersJsonProviderTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/composite/accessevent/ResponseHeadersJsonProviderTest.java
+++ b/src/test/java/net/logstash/logback/composite/accessevent/ResponseHeadersJsonProviderTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/composite/loggingevent/ArgumentsJsonProviderTest.java
+++ b/src/test/java/net/logstash/logback/composite/loggingevent/ArgumentsJsonProviderTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/composite/loggingevent/CallerDataJsonProviderTest.java
+++ b/src/test/java/net/logstash/logback/composite/loggingevent/CallerDataJsonProviderTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/composite/loggingevent/ContextNameJsonProviderTest.java
+++ b/src/test/java/net/logstash/logback/composite/loggingevent/ContextNameJsonProviderTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/composite/loggingevent/LogLevelJsonProviderTest.java
+++ b/src/test/java/net/logstash/logback/composite/loggingevent/LogLevelJsonProviderTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/composite/loggingevent/LogLevelValueJsonProviderTest.java
+++ b/src/test/java/net/logstash/logback/composite/loggingevent/LogLevelValueJsonProviderTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/composite/loggingevent/LoggerNameJsonProviderTest.java
+++ b/src/test/java/net/logstash/logback/composite/loggingevent/LoggerNameJsonProviderTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/composite/loggingevent/LoggingEventCompositeJsonFormatterTest.java
+++ b/src/test/java/net/logstash/logback/composite/loggingevent/LoggingEventCompositeJsonFormatterTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/composite/loggingevent/LoggingEventFormattedTimestampJsonProviderTest.java
+++ b/src/test/java/net/logstash/logback/composite/loggingevent/LoggingEventFormattedTimestampJsonProviderTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/composite/loggingevent/LoggingEventNestedJsonProviderTest.java
+++ b/src/test/java/net/logstash/logback/composite/loggingevent/LoggingEventNestedJsonProviderTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/composite/loggingevent/LoggingEventPatternJsonProviderTest.java
+++ b/src/test/java/net/logstash/logback/composite/loggingevent/LoggingEventPatternJsonProviderTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/composite/loggingevent/LogstashMarkersJsonProviderTest.java
+++ b/src/test/java/net/logstash/logback/composite/loggingevent/LogstashMarkersJsonProviderTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/composite/loggingevent/MdcJsonProviderTest.java
+++ b/src/test/java/net/logstash/logback/composite/loggingevent/MdcJsonProviderTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/composite/loggingevent/MessageJsonProviderTest.java
+++ b/src/test/java/net/logstash/logback/composite/loggingevent/MessageJsonProviderTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/composite/loggingevent/RawMessageJsonProviderTest.java
+++ b/src/test/java/net/logstash/logback/composite/loggingevent/RawMessageJsonProviderTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/composite/loggingevent/RootStackTraceElementJsonProviderTest.java
+++ b/src/test/java/net/logstash/logback/composite/loggingevent/RootStackTraceElementJsonProviderTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/composite/loggingevent/SequenceJsonProviderTest.java
+++ b/src/test/java/net/logstash/logback/composite/loggingevent/SequenceJsonProviderTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/composite/loggingevent/StackHashJsonProviderTest.java
+++ b/src/test/java/net/logstash/logback/composite/loggingevent/StackHashJsonProviderTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/composite/loggingevent/StackTraceJsonProviderTest.java
+++ b/src/test/java/net/logstash/logback/composite/loggingevent/StackTraceJsonProviderTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/composite/loggingevent/TagsJsonProviderTest.java
+++ b/src/test/java/net/logstash/logback/composite/loggingevent/TagsJsonProviderTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/composite/loggingevent/ThreadNameJsonProviderTest.java
+++ b/src/test/java/net/logstash/logback/composite/loggingevent/ThreadNameJsonProviderTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/composite/loggingevent/ThrowableClassNameJsonProviderTest.java
+++ b/src/test/java/net/logstash/logback/composite/loggingevent/ThrowableClassNameJsonProviderTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/composite/loggingevent/ThrowableRootCauseClassNameJsonProviderTest.java
+++ b/src/test/java/net/logstash/logback/composite/loggingevent/ThrowableRootCauseClassNameJsonProviderTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/composite/loggingevent/UuidProviderTest.java
+++ b/src/test/java/net/logstash/logback/composite/loggingevent/UuidProviderTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/decorate/CharacterEscapesJsonFactoryDecoratorTest.java
+++ b/src/test/java/net/logstash/logback/decorate/CharacterEscapesJsonFactoryDecoratorTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/decorate/FeatureJsonFactoryDecoratorTest.java
+++ b/src/test/java/net/logstash/logback/decorate/FeatureJsonFactoryDecoratorTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/encoder/CompositeJsonEncoderTest.java
+++ b/src/test/java/net/logstash/logback/encoder/CompositeJsonEncoderTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/encoder/LogstashAccessEncoderTest.java
+++ b/src/test/java/net/logstash/logback/encoder/LogstashAccessEncoderTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/encoder/LogstashEncoderTest.java
+++ b/src/test/java/net/logstash/logback/encoder/LogstashEncoderTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/layout/CompositeJsonLayoutTest.java
+++ b/src/test/java/net/logstash/logback/layout/CompositeJsonLayoutTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/marker/DeferredLogstashMarkerTest.java
+++ b/src/test/java/net/logstash/logback/marker/DeferredLogstashMarkerTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/marker/MapEntriesAppendingMarkerTest.java
+++ b/src/test/java/net/logstash/logback/marker/MapEntriesAppendingMarkerTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/marker/MarkersTest.java
+++ b/src/test/java/net/logstash/logback/marker/MarkersTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/marker/ObjectAppendingMarkerTest.java
+++ b/src/test/java/net/logstash/logback/marker/ObjectAppendingMarkerTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/marker/ObjectFieldsAppendingMarkerTest.java
+++ b/src/test/java/net/logstash/logback/marker/ObjectFieldsAppendingMarkerTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/marker/RawJsonAppendingMarkerTest.java
+++ b/src/test/java/net/logstash/logback/marker/RawJsonAppendingMarkerTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/mask/MaskingJsonGeneratorDecoratorTest.java
+++ b/src/test/java/net/logstash/logback/mask/MaskingJsonGeneratorDecoratorTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/mask/RegexValueMaskerTest.java
+++ b/src/test/java/net/logstash/logback/mask/RegexValueMaskerTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/pattern/AbstractJsonPatternParserTest.java
+++ b/src/test/java/net/logstash/logback/pattern/AbstractJsonPatternParserTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/pattern/AccessEventJsonPatternParserTest.java
+++ b/src/test/java/net/logstash/logback/pattern/AccessEventJsonPatternParserTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/pattern/LoggingEventJsonPatternParserTest.java
+++ b/src/test/java/net/logstash/logback/pattern/LoggingEventJsonPatternParserTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/stacktrace/ShortenedThrowableConverterTest.java
+++ b/src/test/java/net/logstash/logback/stacktrace/ShortenedThrowableConverterTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/stacktrace/StackHasherTest.java
+++ b/src/test/java/net/logstash/logback/stacktrace/StackHasherTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/stacktrace/StackHasherTest.java
+++ b/src/test/java/net/logstash/logback/stacktrace/StackHasherTest.java
@@ -153,7 +153,7 @@ public class StackHasherTest {
 
             // THEN
             Assertions.assertEquals(1, hashes.size());
-            Assertions.assertEquals("e30d4cae", hashes.getFirst());
+            Assertions.assertEquals("48abcbb0", hashes.getFirst());
         }
     }
 }

--- a/src/test/java/net/logstash/logback/status/LevelFilteringStatusListenerTest.java
+++ b/src/test/java/net/logstash/logback/status/LevelFilteringStatusListenerTest.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/net/logstash/logback/util/ReusableBufferTests.java
+++ b/src/test/java/net/logstash/logback/util/ReusableBufferTests.java
@@ -1,4 +1,6 @@
-/**
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at


### PR DESCRIPTION
Update POM to use the latest version of the Mycila license plugin (and correct GAV).
Move plugin configuration inside the <pluginManagement> section so the plugin can be manually invoked from the command line. Particularly handy to fix header issues automatically…
Change the build process to “check” the files only and fail the build if not valid.

Related issue: #549