### PR TITLE
Maven Shade: exclude MANIFEST and produce shaded SOURCE jar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 .settings/
 .*.md.html
 
+dependency-reduced-pom.xml
+
 META-INF/
 target/
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,6 @@
 .settings/
 .*.md.html
 
-dependency-reduced-pom.xml
-
 META-INF/
 target/
 

--- a/pom.xml
+++ b/pom.xml
@@ -318,7 +318,6 @@
                 <configuration>
                     <shadedArtifactAttached>false</shadedArtifactAttached>
                     <createDependencyReducedPom>true</createDependencyReducedPom>
-                    <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
                     <createSourcesJar>true</createSourcesJar>
                     <shadeSourcesContent>true</shadeSourcesContent>
                     <minimizeJar>true</minimizeJar>

--- a/pom.xml
+++ b/pom.xml
@@ -318,6 +318,7 @@
                 <configuration>
                     <shadedArtifactAttached>false</shadedArtifactAttached>
                     <createDependencyReducedPom>true</createDependencyReducedPom>
+                    <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
                     <createSourcesJar>true</createSourcesJar>
                     <shadeSourcesContent>true</shadeSourcesContent>
                     <minimizeJar>true</minimizeJar>

--- a/pom.xml
+++ b/pom.xml
@@ -318,17 +318,22 @@
                 <configuration>
                     <shadedArtifactAttached>false</shadedArtifactAttached>
                     <createDependencyReducedPom>true</createDependencyReducedPom>
+                    <createSourcesJar>true</createSourcesJar>
+                    <shadeSourcesContent>true</shadeSourcesContent>
                     <minimizeJar>true</minimizeJar>
                     <artifactSet>
-                        <excludes>
-                            <exclude>ch.qos.logback:*</exclude>
-                            <exclude>org.slf4j:*</exclude>
-                            <exclude>org.yaml:*</exclude>
-                            <exclude>com.fasterxml.jackson.core:*</exclude>
-                            <exclude>com.fasterxml.jackson.dataformat:*</exclude>
-                            <exclude>com.fasterxml.uuid:*</exclude>
-                        </excludes>
+                        <includes>
+                            <include>com.lmax:disruptor</include>
+                        </includes>
                     </artifactSet>
+                    <filters>
+                        <filter>
+                            <artifact>com.lmax:disruptor</artifact>
+                            <excludes>
+                                <exclude>META-INF/MANIFEST.MF</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
                     <relocations>
                         <relocation>
                             <pattern>com.lmax.disruptor</pattern>


### PR DESCRIPTION
- exclude MANIFEST from shaded jars to make sure we keep only the one from the project in the final result
- explicitly configure the plugin to <include> the Disruptor and <exclude> all the other dependencies (if not, new project dependencies will be shaded as well if the plugin configuration is not updated)
- produce shaded source as well (handy when debugging applications making use of the library)

Related issue: #553