### PR TITLE
Async append blocking with timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -648,9 +648,10 @@ When the appender drops an event, it emits a warning status message every `dropp
 
 #### Graceful Shutdown
 
-When stopped, async appenders perform a _graceful shutdown_ waiting until all events in the buffer are processed and the buffer is empty.
-The maximum time to wait is configured by the `shutdownGracePeriod` parameter and is set to `1 minute` by default.
+In order to guarantees that logged messages have had a chance to be processed by asynchronous appenders (including the TCP appender) and ensure background threads have been stopped, you'll need to [cleanly shut down logback](http://logback.qos.ch/manual/configuration.html#stopContext) when your application exits.
 
+When gracefully stopped, async appenders wait until all events in the buffer are processed and the buffer is empty.
+The maximum time to wait is configured by the `shutdownGracePeriod` parameter and is set to `1 minute` by default.
 Events still in the buffer after this period is elapsed are dropped and the appender is stopped.
 
 
@@ -771,7 +772,6 @@ e.g.<br/><tt>phasedBackoff{10,60,seconds,blocking}</tt></td>
 See [AsyncDisruptorAppender](/src/main/java/net/logstash/logback/appender/AsyncDisruptorAppender.java)
 for other configuration parameters (such as `ringBufferSize`, `producerType`, `threadNamePrefix`, `daemon`, and `droppedWarnFrequency`)
 
-In order to guarantees that logged messages have had a chance to be processed by asynchronous appenders (including the TCP appender) and ensure background threads have been stopped, you'll need to [cleanly shut down logback](http://logback.qos.ch/manual/configuration.html#stopContext) when your application exits.
 
 ### Appender Listeners
 

--- a/pom.xml
+++ b/pom.xml
@@ -211,6 +211,12 @@
             <version>${org.mockito.version}</version>
             <scope>test</scope>
         </dependency>
+<dependency>
+    <groupId>org.awaitility</groupId>
+    <artifactId>awaitility</artifactId>
+    <version>4.1.0</version>
+    <scope>test</scope>
+</dependency>
     </dependencies>
 
     <build>

--- a/src/test/java/net/logstash/logback/appender/AsyncDisruptorAppenderTest.java
+++ b/src/test/java/net/logstash/logback/appender/AsyncDisruptorAppenderTest.java
@@ -16,6 +16,7 @@
 package net.logstash.logback.appender;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -23,17 +24,26 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import net.logstash.logback.appender.AsyncDisruptorAppender.AsyncMode;
 import net.logstash.logback.appender.AsyncDisruptorAppender.LogEvent;
 import net.logstash.logback.appender.listener.AppenderListener;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.BasicStatusManager;
 import ch.qos.logback.core.Context;
 import ch.qos.logback.core.status.Status;
 import ch.qos.logback.core.status.StatusManager;
@@ -46,6 +56,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.stubbing.Answer;
@@ -64,8 +75,8 @@ public class AsyncDisruptorAppenderTest {
     @Mock(lenient = true)
     private Context context;
     
-    @Mock
-    private StatusManager statusManager;
+    @Spy
+    private StatusManager statusManager = new BasicStatusManager();
     
     @Mock
     private ILoggingEvent event1;
@@ -198,7 +209,6 @@ public class AsyncDisruptorAppenderTest {
         Assertions.assertTrue(statusCaptor.getValue().getMessage().startsWith("Dropped"));
         
         eventHandlerWaiter.countDown();
-        
     }
 
     @SuppressWarnings("unchecked")
@@ -220,4 +230,175 @@ public class AsyncDisruptorAppenderTest {
         
     }
 
+    /*
+     * Appender is configured to block indefinitely when ring buffer is full 
+     */
+    @Test
+    public void appendBlockingWhenFull() {
+        CountDownLatch eventHandlerWaiter = new CountDownLatch(1);
+
+        try {
+            TestEventHandler eventHandler = new TestEventHandler(eventHandlerWaiter);
+            appender.setRingBufferSize(1);
+            appender.setAsyncMode(AsyncMode.BLOCK);
+            appender.setEventHandler(eventHandler);
+            appender.start();
+            
+            /*
+             * First event blocks the ring buffer until eventHandlerWaiter is released
+             */
+            appender.append(event1);
+            await().until(() -> eventHandlerWaiter.getCount()==1); // wait until the handler is actually invoked before going any further
+            
+            /*
+             * Publishing the second event is blocked until the first is released (buffer full)
+             */
+            Future<?> future = execute(() -> appender.append(event2));
+            
+            /*
+             * Release the handler -> both events are now unblocked
+             */
+            eventHandlerWaiter.countDown();
+    
+            await().untilAsserted(() -> assertThat(eventHandler.getEvents()).containsExactly(event1, event2));
+            assertThat(future).isDone();
+            assertThat(statusManager.getCopyOfStatusList()).isEmpty();
+            
+        } finally {
+            eventHandlerWaiter.countDown();
+        }
+    }
+    
+    
+    /*
+     * Appender configured in async "block" mode -> assert appending threads are blocked for the 
+     * configured timeout.
+     */
+    @Test
+    public void appendBlockingWithTimeout() throws Exception {
+        // Block for the specified timeout
+        final Duration timeout = Duration.ofMillis(150);
+        
+        final CountDownLatch eventHandlerWaiter = new CountDownLatch(1);
+        
+        try {
+            TestEventHandler eventHandler = new TestEventHandler(eventHandlerWaiter);
+            appender.setRingBufferSize(1);
+            appender.setAsyncMode(AsyncMode.BLOCK);
+            appender.setRetryTimeout(toLogback(timeout));
+            appender.setEventHandler(eventHandler);
+            appender.start();
+            
+            /*
+             * First event blocks the ring buffer until eventHandlerWaiter is released
+             */
+            appender.append(event1);
+            await().until(() -> eventHandlerWaiter.getCount()==1); // wait until the handler is actually invoked before going any further
+            
+            
+            /*
+             * Second event is blocked until the first is released (buffer full) - but no more than the configured timeout
+             */
+            Future<?> future = execute(() -> appender.append(event2));
+            
+            // wait for the timeout
+            await().atLeast(timeout).and().atMost(timeout.plusMillis(100)).until(future::isDone);
+            
+            // a WARN status is logged
+            assertThat(statusManager.getCopyOfStatusList())
+                .hasSize(1)
+                .allMatch(s -> s.getMessage().startsWith("Dropped"));
+            
+            // listeners invoked with appendFailed 
+            verify(listener).eventAppendFailed(eq(appender), eq(event2), any());
+            
+            
+            /*
+             * Unlock the handler and assert only the first event went through
+             */
+            eventHandlerWaiter.countDown();
+            await().untilAsserted( () -> assertThat(eventHandler.getEvents()).containsExactly(event1) );
+            
+        } finally {
+            eventHandlerWaiter.countDown();
+        }
+    }
+    
+    
+    /*
+     * Appender configured in async "block" mode -> assert threads blocked waiting for free space are 
+     * released when the appender is stopped
+     */
+    @Test
+    public void appendBlockingReleasedOnStop() {
+        final CountDownLatch eventHandlerWaiter = new CountDownLatch(1);
+        
+        try {
+            TestEventHandler eventHandler = new TestEventHandler(eventHandlerWaiter);
+            appender.setRingBufferSize(1);
+            appender.setAsyncMode(AsyncMode.BLOCK);
+            appender.setShutdownGracePeriod(toLogback(Duration.ofMillis(0))); // don't want to wait for inflight events...
+            appender.setEventHandler(eventHandler);
+            appender.start();
+            
+            /*
+             * First event will block the ring buffer until eventHandlerWaiter is released
+             */
+            appender.append(event1);
+            await().until(() -> eventHandlerWaiter.getCount()==1); // wait until the handler is actually invoked before going any further
+            
+            /*
+             * Publishing the second event is blocked until the first is released (buffer full)
+             */
+            Future<?> future = execute(() -> appender.append(event2));
+            
+            /*
+             * Stop appender
+             */
+            appender.stop();
+            
+            // appending thread is released
+            await().until(future::isDone);
+
+            // no events handled
+            assertThat(eventHandler.getEvents()).isEmpty();
+
+            // no listener invoked
+            verify(listener, times(0)).eventAppendFailed(eq(appender), eq(event2), any());
+            
+        } finally {
+            eventHandlerWaiter.countDown();
+        }
+    }
+    
+
+    private ExecutorService executorService = Executors.newCachedThreadPool();
+    
+    private Future<?> execute(Runnable runnable) {
+        return executorService.submit(runnable);
+    }
+       
+    private static class TestEventHandler implements EventHandler<LogEvent<ILoggingEvent>> {
+        private final List<ILoggingEvent> events = new ArrayList<>();
+        private final CountDownLatch waiter;
+        
+        public TestEventHandler(CountDownLatch waiter) {
+            this.waiter = waiter;
+        }
+        @Override
+        public void onEvent(LogEvent<ILoggingEvent> event, long sequence, boolean endOfBatch) throws Exception {
+            if (waiter != null ) {
+                waiter.await();
+            }
+            this.events.add(event.event);
+        }
+        
+        public List<ILoggingEvent> getEvents() {
+            return events;
+        }
+    }
+    
+    private static ch.qos.logback.core.util.Duration toLogback(Duration duration) {
+        return ch.qos.logback.core.util.Duration.buildByMilliseconds(duration.toMillis());
+    }
 }


### PR DESCRIPTION
Please have a look at this first draft implementation for #559.

In short, the appender supports two distinct operation modes (set via `asyncMode`):
- `DROP` (the default): the appender drops events when the ring buffer is full. This is the legacy behaviour.
- `BLOCK`: the appending thread is blocked when the buffer is full until some free space becomes available. An optional timeout can be specified using the `retryTimeout` configuration property (disabled by default).

The RingBuffer does not allow me to "publish with a timeout" - it offers either a "try publish" or a "publish". The later blocks indefinitely until there is enough space in the buffer to accept the event. Even worst, waiting threads are not unblocked when the disruptor is shutdown.
Instead, I decided to tryPublish and sleep before retrying until the optional timeout expires. Sleeping is done using `LockSupport.parkNanos()` just like what the Disruptor does too. Retries are scheduled every 100ms which may appear to be too frequent (CPU?). The problem is there is no way I'm aware of that tells me when there is room in the ring buffer. May be I can hook into the EvenHandler and awake any waiting threads when an event has been processed... This means a queue of waiting threads and potential synchronisation issues and/or performance impacts...

Instead of `asyncMode` and `retryTimeout` (feel free to comment on the name of these properties) it may be more convenient to collapse them into a single `appendTimeout` configuration property whose semantic would be:
- `-1`: timeout is disabled, means block until space is available (aka the `BLOCK` mode)
- `0`: times out immediately (aka the `DROP` mode) - this would be the default behaviour
- `>0`: times out after the given time
When the appender times out, it drops the event and logs a warning as it does already.

@philsttr Feedback?