### PR TITLE
Release/clear LogEvent early before end of batch (gh568)

### DIFF
--- a/src/main/java/net/logstash/logback/appender/AsyncDisruptorAppender.java
+++ b/src/main/java/net/logstash/logback/appender/AsyncDisruptorAppender.java
@@ -447,11 +447,11 @@ public abstract class AsyncDisruptorAppender<Event extends DeferredProcessingAwa
          * do not hold up shutdown.
          */
         this.executorService.setRemoveOnCancelPolicy(true);
-     
+
         this.disruptor = new Disruptor<LogEvent<Event>>(
                 this.eventFactory,
                 this.ringBufferSize,
-                this.threadFactory,
+                this.executorService,
                 this.producerType,
                 this.waitStrategy);
 

--- a/src/test/java/net/logstash/logback/appender/DelegatingAsyncDisruptorAppenderTest.java
+++ b/src/test/java/net/logstash/logback/appender/DelegatingAsyncDisruptorAppenderTest.java
@@ -251,7 +251,7 @@ public class DelegatingAsyncDisruptorAppenderTest {
         appender.append(event);
         
         verify(flushableDelegate, timeout(VERIFICATION_TIMEOUT)).doAppend(event);
-        verify(flushableDelegate).flush();
+        verify(flushableDelegate, timeout(VERIFICATION_TIMEOUT)).flush();
     }
 
 


### PR DESCRIPTION
This PR modifies the `EventClearingEventHandler` such that it notifies the `BatchEventProcessor` that the sequence has progressed after every event. Without this callback the sequence would not be progressed until the batch has completely finished.

@philsttr Could you have a look and tell me what you think about it?
