### PR TITLE
Setup Github "cache" action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
   - push
   - pull_request
 
+env:
+  JAVA_OPTS: "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
+
 jobs:
   build:
     name: build
@@ -12,8 +15,6 @@ jobs:
       fail-fast: false
       matrix:
         java: [ '8', '11', '16' ]
-    env:
-      JAVA_OPTS: "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
     steps:
       - uses: actions/checkout@v2
       - name: Setup JDK
@@ -26,7 +27,7 @@ jobs:
           path: |
             ~/.m2/repository
             ~/.m2/wrapper
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml', '.mvn/maven-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Build
@@ -37,8 +38,6 @@ jobs:
     if: github.event_name == 'push' && github.repository == 'logstash/logstash-logback-encoder' && github.ref == 'refs/heads/main' && startsWith(github.event.commits[0].message, '[release]')
     runs-on: ubuntu-20.04
     needs: [build]
-    env:
-      JAVA_OPTS: "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
     steps:
       - uses: actions/checkout@v2
         with:
@@ -62,7 +61,7 @@ jobs:
           path: |
             ~/.m2/repository
             ~/.m2/wrapper
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml', '.mvn/maven-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         java: [ '8', '11', '16' ]
     steps:
       - uses: actions/checkout@v2
-      - name: Setup JDK
+      - name: Setup JAVA
         uses: actions/setup-java@v2
         with:
           distribution: "adopt"
@@ -27,7 +27,7 @@ jobs:
           path: |
             ~/.m2/repository
             ~/.m2/wrapper
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml', '.mvn/maven-wrapper.properties') }}
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml', '.mvn/wrapper/maven-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Build
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: main
-      - name: Setup JDK
+      - name: Setup JAVA
         uses: actions/setup-java@v2
         with:
           distribution: "adopt"
@@ -61,7 +61,7 @@ jobs:
           path: |
             ~/.m2/repository
             ~/.m2/wrapper
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml', '.mvn/maven-wrapper.properties') }}
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml', '.mvn/wrapper/maven-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,38 +9,59 @@ jobs:
     name: build
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         java: [ '8', '11', '16' ]
+      env:
+        JAVA_OPTS: "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
     steps:
-      - uses: actions/checkout@v1.1.0
-      - name: setup JDK
-        uses: actions/setup-java@v1
+      - uses: actions/checkout@v2
+      - name: Setup JDK
+        uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.java }}
-      - name: build
+      - uses: actions/cache@v2.1.6
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.m2/wrapper
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Build
         run: ./mvnw --batch-mode --no-transfer-progress --show-version --settings .github/maven/settings.xml verify
+
   release:
     name: release
     if: github.event_name == 'push' && github.repository == 'logstash/logstash-logback-encoder' && github.ref == 'refs/heads/main' && startsWith(github.event.commits[0].message, '[release]')
     runs-on: ubuntu-20.04
     needs: [build]
     steps:
-      - uses: actions/checkout@v1.1.0
+      - uses: actions/checkout@v2
         with:
           ref: main
-      - uses: actions/setup-java@v1
+      - name: Setup JDK
+        uses: actions/setup-java@v2
         with:
           java-version: 1.8
-      - name: setup-gpg
+      - name: Setup GPG
         run: .github/workflows/steps/setup-gpg.sh
         env:
           GPG_KEY: ${{ secrets.GPG_KEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-      - name: setup-git
+      - name: Setup GIT
         run: |
           .github/workflows/steps/setup-git.sh
           git switch main
-      - name: release
+      - uses: actions/cache@v2.1.6
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.m2/wrapper
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Release
         run: ./mvnw --batch-mode --no-transfer-progress --show-version --settings .github/maven/settings.xml --activate-profiles ossrh release:prepare release:perform
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,8 @@ jobs:
       fail-fast: false
       matrix:
         java: [ '8', '11', '16' ]
-      env:
-        JAVA_OPTS: "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
+    env:
+      JAVA_OPTS: "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
     steps:
       - uses: actions/checkout@v2
       - name: Setup JDK
@@ -36,6 +36,8 @@ jobs:
     if: github.event_name == 'push' && github.repository == 'logstash/logstash-logback-encoder' && github.ref == 'refs/heads/main' && startsWith(github.event.commits[0].message, '[release]')
     runs-on: ubuntu-20.04
     needs: [build]
+    env:
+      JAVA_OPTS: "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v2
         with:
+          distribution: "adopt"
           java-version: ${{ matrix.java }}
       - uses: actions/cache@v2.1.6
         with:
@@ -45,6 +46,7 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v2
         with:
+          distribution: "adopt"
           java-version: 1.8
       - name: Setup GPG
         run: .github/workflows/steps/setup-gpg.sh


### PR DESCRIPTION
- Enable caching of local maven repo + wrapper
- Use "adopt" JDK instead of "Zulu"
- Speedup Maven execution by limiting the compiler at tier 1 (java process won't last long enough to benefit from more aggressive optimisations)

closes #597