### PR TITLE
Implement exponential backoff for the retry strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ The structure of the output, and the data it contains, is fully configurable.
     * [Write Timeouts](#write-timeouts)
     * [SSL](#ssl)
   * [Async Appenders](#async-appenders)
+  	* [RingBuffer Full](#ringbuffer-full)
+  	* [Graceful Shutdown](#graceful-shutdown)
+  	* [Wait Strategy](#wait-strategy)
   * [Appender Listeners](#appender-listeners)
   * [Encoders / Layouts](#encoders--layouts)
 * [LoggingEvent Fields](#loggingevent-fields)
@@ -660,7 +663,7 @@ The behaviour of the appender when the RingBuffer is controlled by the `appendTi
 | `> 0`           | retry during the specified amount of time                              |
 
 
-Logging threads waiting for space in the RingBuffer wake up periodically at a frequency defined by  `appendRetryFrequency` (default `50ms`). You may increase this frequency for faster reaction time at the expense of higher CPU usage.
+Logging threads waiting for space in the RingBuffer wake up periodically at a frequency defined by  `appendRetryFrequency` (default `5ms`). You may increase this frequency for faster reaction time at the expense of higher CPU usage.
 
 When the appender drops an event, it emits a warning status message every `droppedWarnFrequency` consecutive dropped events. Another status message is emitted when the drop period is over and a first event is succesfully enqueued reporting the total number of events that were dropped.
 
@@ -676,8 +679,7 @@ Events still in the buffer after this period is elapsed are dropped and the appe
 
 #### Wait Strategy
 
-By default, the [`BlockingWaitStrategy`](https://lmax-exchange.github.io/disruptor/docs/com/lmax/disruptor/BlockingWaitStrategy.html)
-is used by the worker thread spawned by this appender.
+By default, the [`BlockingWaitStrategy`](https://lmax-exchange.github.io/disruptor/docs/com/lmax/disruptor/BlockingWaitStrategy.html) is used by the worker thread spawned by this appender.
 The `BlockingWaitStrategy` minimizes CPU utilization, but results in slower latency and throughput.
 If you need faster latency and throughput (at the expense of higher CPU utilization), consider
 a different [wait strategy](https://lmax-exchange.github.io/disruptor/docs/com/lmax/disruptor/WaitStrategy.html) offered by the disruptor.

--- a/README.md
+++ b/README.md
@@ -663,7 +663,8 @@ The behaviour of the appender when the RingBuffer is controlled by the `appendTi
 | `> 0`           | retry during the specified amount of time                              |
 
 
-Logging threads waiting for space in the RingBuffer wake up periodically at a frequency defined by  `appendRetryFrequency` (default `5ms`). You may increase this frequency for faster reaction time at the expense of higher CPU usage.
+Logging threads waiting for space in the RingBuffer wake up periodically at a frequency starting at `1ns` and increasing exponentially up to `appendRetryFrequency` (default `5ms`). 
+Only one thread is allowed to retry at a time. If a thread is already retrying, additional threads are waiting on a lock until the first is finished. This strategy should help to limit CPU consumption while providing good enough latency and throughput when the ring buffer is at (or close) to its maximal capacity.
 
 When the appender drops an event, it emits a warning status message every `droppedWarnFrequency` consecutive dropped events. Another status message is emitted when the drop period is over and a first event is succesfully enqueued reporting the total number of events that were dropped.
 

--- a/src/main/java/net/logstash/logback/appender/AsyncDisruptorAppender.java
+++ b/src/main/java/net/logstash/logback/appender/AsyncDisruptorAppender.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.LockSupport;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 
 import net.logstash.logback.appender.listener.AppenderListener;
@@ -259,12 +260,17 @@ public abstract class AsyncDisruptorAppender<Event extends DeferredProcessingAwa
      * Delay between consecutive attempts to append an event in the ring buffer when
      * full.
      */
-    private Duration appendRetryFrequency = Duration.buildByMilliseconds(50);
+    private Duration appendRetryFrequency = Duration.buildByMilliseconds(5);
     
     /**
      * How long to wait for in-flight events during shutdown.
      */
     private Duration shutdownGracePeriod = Duration.buildByMinutes(1);
+
+    /**
+     * Lock used to limit the number of concurrent threads retrying at the same time
+     */
+    private final ReentrantLock lock = new ReentrantLock();
 
     
     /**
@@ -425,7 +431,7 @@ public abstract class AsyncDisruptorAppender<Event extends DeferredProcessingAwa
             getStatusManager().add(statusListener);
         }
 
-        this.disruptor = new Disruptor<LogEvent<Event>>(
+        this.disruptor = new Disruptor<>(
                 this.eventFactory,
                 this.ringBufferSize,
                 this.threadFactory,
@@ -504,18 +510,19 @@ public abstract class AsyncDisruptorAppender<Event extends DeferredProcessingAwa
             addWarn("Unable to prepare event for deferred processing. Event output might be missing data.", e);
         }
 
-        
-        // Add event to the buffer, retrying as many times as allowed by the configuration
-        //
-        long deadline = this.appendTimeout.getMilliseconds() < 0 ? Long.MAX_VALUE : System.currentTimeMillis() + this.appendTimeout.getMilliseconds();
-
-        while (!this.disruptor.getRingBuffer().tryPublishEvent(this.eventTranslator, event)) {
-            // Wait before retrying
-            //
-            long waitDuration = Math.min(this.appendRetryFrequency.getMilliseconds(), deadline - System.currentTimeMillis());
-            if (waitDuration > 0) {
-                LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(waitDuration));
-
+        try {
+            if (enqueue(event)) {
+                // Log warning if we had drop before
+                //
+                long consecutiveDropped = this.consecutiveDroppedCount.get();
+                if (consecutiveDropped != 0 && this.consecutiveDroppedCount.compareAndSet(consecutiveDropped, 0L)) {
+                    addWarn("Dropped " + consecutiveDropped + " total events due to ring buffer at max capacity [" + this.ringBufferSize + "]");
+                }
+                
+                // Notify listeners
+                //
+                fireEventAppended(event, System.nanoTime() - startTime);
+                
             } else {
                 // Log a warning status about the failure
                 //
@@ -523,34 +530,77 @@ public abstract class AsyncDisruptorAppender<Event extends DeferredProcessingAwa
                 if ((consecutiveDropped % this.droppedWarnFrequency) == 1) {
                     addWarn("Dropped " + consecutiveDropped + " events (and counting...) due to ring buffer at max capacity [" + this.ringBufferSize + "]");
                 }
-                
+              
                 // Notify listeners
                 //
                 fireEventAppendFailed(event, RING_BUFFER_FULL_EXCEPTION);
-                return;
             }
             
-            // Give up if appender is stopped meanwhile
-            //
-            if (!isStarted()) {
-                // Same message as if Appender#append is called after the appender is stopped...
-                addWarn("Attempted to append to non started appender [" + this.getName() + "].");
-                return;
-            }
+        } catch (ShutdownInProgressException e) {
+            // Same message as if Appender#append is called after the appender is stopped...
+            addWarn("Attempted to append to non started appender [" + this.getName() + "].");
         }
-        
-        // Enqueue success - notify end of error period
-        //
-        long consecutiveDropped = this.consecutiveDroppedCount.get();
-        if (consecutiveDropped != 0 && this.consecutiveDroppedCount.compareAndSet(consecutiveDropped, 0L)) {
-            addWarn("Dropped " + consecutiveDropped + " total events due to ring buffer at max capacity [" + this.ringBufferSize + "]");
-        }
-        
-        // Notify listeners
-        //
-        fireEventAppended(event, System.nanoTime() - startTime);
     }
 
+    
+    /**
+     * Enqueue an event in the ring buffer, retrying if allowed by the configuration.
+     * 
+     * @param event the event to add to the ring buffer
+     * @return {@code true} if the event is successfully enqueued, {@code false} if the event
+     *         could not be added to the ring buffer.
+     * @throws ShutdownInProgressException thrown when the appender is shutdown while retrying
+     *         to enqueue the event
+     */
+    private boolean enqueue(Event event) throws ShutdownInProgressException {
+        // Try enqueue the "normal" way
+        //
+        if (this.disruptor.getRingBuffer().tryPublishEvent(this.eventTranslator, event)) {
+            return true;
+        }
+        
+        // Drop event immediately when no retry
+        //
+        if (this.appendTimeout.getMilliseconds() == 0) {
+            return false;
+        }
+        
+        // Determine how long we can retry
+        //
+        long deadline = this.appendTimeout.getMilliseconds() < 0
+                ? Long.MAX_VALUE
+                : System.currentTimeMillis() + this.appendTimeout.getMilliseconds();
+
+        long backoff = 1L;
+        long backoffLimit = TimeUnit.MILLISECONDS.toNanos(this.appendRetryFrequency.getMilliseconds());
+
+        
+        // Limit retries to a single thread at once to avoid burning CPU cycles "for nothing"
+        // in CPU constraint environments.
+        //
+        lock.lock();
+        try {
+            do {
+                if (deadline <= System.currentTimeMillis()) {
+                    return false;
+                }
+                
+                if (!isStarted()) {
+                    throw new ShutdownInProgressException();
+                }
+
+                LockSupport.parkNanos(backoff);
+                backoff = Math.min(backoff * 2, backoffLimit);
+
+            } while (!this.disruptor.getRingBuffer().tryPublishEvent(this.eventTranslator, event));
+
+            return true;
+            
+        } finally {
+            lock.unlock();
+        }
+    }
+    
     protected void prepareForDeferredProcessing(Event event) {
         event.prepareForDeferredProcessing();
     }

--- a/src/test/java/net/logstash/logback/appender/AsyncDisruptorAppenderTest.java
+++ b/src/test/java/net/logstash/logback/appender/AsyncDisruptorAppenderTest.java
@@ -94,7 +94,6 @@ public class AsyncDisruptorAppenderTest {
     public void setup() {
         when(context.getStatusManager()).thenReturn(statusManager);
 
-        appender.setAddDefaultStatusListener(false);
         appender.addListener(listener);
     }
     


### PR DESCRIPTION
The initial retries start very fast (a few nanoseconds pauses) and slow down up to the configure `appendRetryTimeout`.
In addition, limit retry to a single concurrent thread to preserve CPU in constraint environments.
These changes should give a better throughput with an acceptable latency when the queue is full.

Closes #619