### PR TITLE
Deprecate AbstractLogstashTcpSocketAppender#secondaryConnectionTTL

### DIFF
--- a/src/main/java/net/logstash/logback/appender/AbstractLogstashTcpSocketAppender.java
+++ b/src/main/java/net/logstash/logback/appender/AbstractLogstashTcpSocketAppender.java
@@ -1173,8 +1173,13 @@ public abstract class AbstractLogstashTcpSocketAppender<Event extends DeferredPr
      * @see PreferPrimaryDestinationConnectionStrategy#setSecondaryConnectionTTL(Duration)
      * @param secondaryConnectionTTL the TTL of a connection when connected to a secondary destination
      * @throws IllegalStateException if the {@link #connectionStrategy} is not a {@link PreferPrimaryDestinationConnectionStrategy}
+     * 
+     * @deprecated use {@link PreferPrimaryDestinationConnectionStrategy#setSecondaryConnectionTTL(Duration)} instead.
      */
+    @Deprecated
     public void setSecondaryConnectionTTL(Duration secondaryConnectionTTL) {
+        addWarn("Setting <secondaryConnectionTTL> on the appender is deprecated, set it on the connection strategy using <preferPrimary.secondaryConnectionTTL> instead.");
+
         if (connectionStrategy instanceof PreferPrimaryDestinationConnectionStrategy) {
             ((PreferPrimaryDestinationConnectionStrategy) connectionStrategy).setSecondaryConnectionTTL(secondaryConnectionTTL);
         } else {
@@ -1182,6 +1187,16 @@ public abstract class AbstractLogstashTcpSocketAppender<Event extends DeferredPr
         }
     }
 
+    /**
+     * Convenience method for accessing {@link PreferPrimaryDestinationConnectionStrategy#getSecondaryConnectionTTL()}.
+     * 
+     * @return the secondary connection TTL or {@code null} if the connection strategy is not a {@link PreferPrimaryDestinationConnectionStrategy}.
+     * @deprecated use {@link PreferPrimaryDestinationConnectionStrategy#getSecondaryConnectionTTL()} instead.
+     * 
+     * @see #getConnectionStrategy()
+     * @see PreferPrimaryDestinationConnectionStrategy#getSecondaryConnectionTTL()
+     */
+    @Deprecated
     public Duration getSecondaryConnectionTTL() {
         if (connectionStrategy instanceof PreferPrimaryDestinationConnectionStrategy) {
             return ((PreferPrimaryDestinationConnectionStrategy) connectionStrategy).getSecondaryConnectionTTL();
@@ -1237,7 +1252,7 @@ public abstract class AbstractLogstashTcpSocketAppender<Event extends DeferredPr
      * Alias for {@link #getRingBufferSize()}.
      * 
      * @return the size of the ring buffer
-     * @deprecated use {@link #getRingBufferSize()} instead
+     * @deprecated use {@link #getRingBufferSize()} instead.
      */
     @Deprecated
     public int getQueueSize() {

--- a/src/main/java/net/logstash/logback/appender/AbstractLogstashTcpSocketAppender.java
+++ b/src/main/java/net/logstash/logback/appender/AbstractLogstashTcpSocketAppender.java
@@ -1178,7 +1178,9 @@ public abstract class AbstractLogstashTcpSocketAppender<Event extends DeferredPr
      */
     @Deprecated
     public void setSecondaryConnectionTTL(Duration secondaryConnectionTTL) {
-        addWarn("Setting <secondaryConnectionTTL> on the appender is deprecated, set it on the connection strategy using <preferPrimary.secondaryConnectionTTL> instead.");
+        addWarn(
+              "Setting <secondaryConnectionTTL> directly on the appender is deprecated. "
+            + "Instead you should explicitly set the connection strategy to <preferPrimary> and set its <secondaryConnectionTTL> property to the desired value.");
 
         if (connectionStrategy instanceof PreferPrimaryDestinationConnectionStrategy) {
             ((PreferPrimaryDestinationConnectionStrategy) connectionStrategy).setSecondaryConnectionTTL(secondaryConnectionTTL);

--- a/src/test/java/net/logstash/logback/appender/LogstashTcpSocketAppenderTest.java
+++ b/src/test/java/net/logstash/logback/appender/LogstashTcpSocketAppenderTest.java
@@ -61,6 +61,7 @@ import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.BasicStatusManager;
 import ch.qos.logback.core.encoder.Encoder;
+import ch.qos.logback.core.status.OnConsoleStatusListener;
 import ch.qos.logback.core.status.Status;
 import ch.qos.logback.core.status.StatusManager;
 import ch.qos.logback.core.util.Duration;
@@ -83,8 +84,6 @@ public class LogstashTcpSocketAppenderTest {
 
     @InjectMocks
     private final LogstashTcpSocketAppender appender = new TestableLogstashTcpSocketAppender();
-    
-    private LoggerContext context = new LoggerContext();
     
     private StatusManager statusManager = new BasicStatusManager();
     
@@ -121,6 +120,13 @@ public class LogstashTcpSocketAppenderTest {
     
     @BeforeEach
     public void setup() throws IOException {
+        // Output statuses on the console for easy debugging. Must be initialized early to capture
+        // warnings emitted by setter/getter methods before the appender is started.
+        OnConsoleStatusListener consoleListener = new OnConsoleStatusListener();
+        consoleListener.start();
+        statusManager.add(consoleListener);
+        
+        LoggerContext context = new LoggerContext();
         context.setStatusManager(statusManager);
         
         when(socketFactory.createSocket()).thenReturn(socket);


### PR DESCRIPTION
Keep current behaviour for backward compatibility.
Emit a WARN status when the property is set.

fixes #633 