### PR TITLE
Refactor AsyncAppenderDisruptor event handling

### DIFF
--- a/src/main/java/net/logstash/logback/appender/AbstractLogstashTcpSocketAppender.java
+++ b/src/main/java/net/logstash/logback/appender/AbstractLogstashTcpSocketAppender.java
@@ -919,10 +919,14 @@ public abstract class AbstractLogstashTcpSocketAppender<Event extends DeferredPr
 
     public AbstractLogstashTcpSocketAppender() {
         super();
-        setEventHandler(new TcpSendingEventHandler());
         setThreadNameFormat(DEFAULT_THREAD_NAME_FORMAT);
     }
 
+    @Override
+    protected EventHandler<LogEvent<Event>> createEventHandler() {
+        return new TcpSendingEventHandler();
+    }
+    
     @Override
     public boolean isStarted() {
         CountDownLatch latch = this.shutdownLatch;

--- a/src/main/java/net/logstash/logback/appender/AsyncDisruptorAppender.java
+++ b/src/main/java/net/logstash/logback/appender/AsyncDisruptorAppender.java
@@ -278,7 +278,7 @@ public abstract class AsyncDisruptorAppender<Event extends DeferredProcessingAwa
      * Factory for creating the initial {@link LogEvent}s to populate
      * the {@link RingBuffer}.
      */
-    private static class LogEventFactory<Event> implements EventFactory<LogEvent<Event>> {
+    protected static class LogEventFactory<Event> implements EventFactory<LogEvent<Event>> {
 
         @Override
         public LogEvent<Event> newInstance() {

--- a/src/main/java/net/logstash/logback/appender/AsyncDisruptorAppender.java
+++ b/src/main/java/net/logstash/logback/appender/AsyncDisruptorAppender.java
@@ -272,6 +272,13 @@ public abstract class AsyncDisruptorAppender<Event extends DeferredProcessingAwa
          * The logback event.
          */
         public volatile Event event;
+        
+        /**
+         * Recycle the instance before it is reused by the RingBuffer.
+         */
+        public void recycle() {
+            this.event = null;
+        }
     }
 
     /**
@@ -358,7 +365,7 @@ public abstract class AsyncDisruptorAppender<Event extends DeferredProcessingAwa
                 /*
                  * Clear the event so that it can be garbage collected.
                  */
-                event.event = null;
+                event.recycle();
                 
                 /*
                  * Notify the BatchEventProcessor that the sequence has progressed.

--- a/src/main/java/net/logstash/logback/appender/DelegatingAsyncDisruptorAppender.java
+++ b/src/main/java/net/logstash/logback/appender/DelegatingAsyncDisruptorAppender.java
@@ -53,7 +53,7 @@ public abstract class DelegatingAsyncDisruptorAppender<Event extends DeferredPro
     /**
      * The delegate appenders.
      */
-    private final AppenderAttachableImpl<Event> appenders = new AppenderAttachableImpl<Event>();
+    private final AppenderAttachableImpl<Event> appenders = new AppenderAttachableImpl<>();
     
     private class DelegatingEventHandler implements EventHandler<LogEvent<Event>> {
         /**
@@ -118,9 +118,9 @@ public abstract class DelegatingAsyncDisruptorAppender<Event extends DeferredPro
         }
     }
     
-    public DelegatingAsyncDisruptorAppender() {
-        super();
-        setEventHandler(new DelegatingEventHandler());
+    @Override
+    protected EventHandler<LogEvent<Event>> createEventHandler() {
+        return new DelegatingEventHandler();
     }
     
     @Override


### PR DESCRIPTION
(1)
Introduce a `#createEventHandler()` method to provide the EventHandler instead of a simple setter method.
Reasons include:
- providing an EventHandler is mandatory. Using an abstract method makes obvious one is required whereas a simple setter supposes it may be optional (until start() is called... which is at runtime, and therefore too late).
- inheriting classes must call `#setEventHandler()` in their constructor - the base class does not have control as to when the handler is actually created. Also, if a class wants to extend `AsyncDisruptorAppender` to provide its own implementation, a first handler will be created and set by AsyncDisruptorAppender's constructor before it is overridden by the one provided by the extending class. Using a factory method solves that issue.
- sub-classes may decide if a new instance of their handler must be used every time the appender is start/stop or if the same instance can be reused.

(2)
Make `LogEventFactory` class protected instead of private otherwise the protected method `#setEventFactory(LogEventFactory)` cannot be used by extending classes...

(3)
Sub-classes of the AsyncDisruptorAppender may provide their own LogEventFactory and LogEventTranslator. They may also work with an extended version of the base LogEvent with additional fields. Recycling these instances may therefore require more than simply setting the `event` field back to null before the instance is returned to the RingBuffer.
This commit adds a `LogEvent#recycle()` method whose job is to perform the needed tasks on the log event before it can be reused. It is called by the `EventClearingEventHandler` wrapper after the event is processed by the EventHandler.