### PR TITLE
Throw IllegalArgumentException at invalid time zone textual representation instead of defaulting to GMT

### DIFF
--- a/README.md
+++ b/README.md
@@ -1639,7 +1639,36 @@ You can change the timezone like this:
 </encoder>
 ```
 
-The value of the `timeZone` element can be any string accepted by java's  `TimeZone.getTimeZone(String id)` method.
+The value of the `timeZone` element can be any string accepted by java's `TimeZone.getTimeZone(String id)` method.
+
+It can be a valid time zone ID. For instance, the time zone ID for the U.S. Pacific Time zone is "America/Los_Angeles".
+
+If the time zone you want is not represented by one of the supported IDs, then a custom time zone ID can be specified to produce a TimeZone. The syntax of a custom time zone ID is:
+
+```
+   CustomID:
+      GMT Sign Hours : Minutes
+      GMT Sign Hours Minutes
+      GMT Sign Hours
+      
+   Sign: one of
+      + -
+   
+   Hours:
+      Digit
+         Digit Digit
+         
+      Minutes:
+         Digit Digit
+
+      Digit: one of
+         0 1 2 3 4 5 6 7 8 9
+```
+
+_Hours_ must be between 0 to 23 and _Minutes_ must be between 00 to 59. 
+For example, "GMT+10" and "GMT+0010" mean ten hours and ten minutes ahead of GMT, respectively.
+
+Use a blank string or `null` to use the default TimeZone of the system.
 
 
 ## Customizing LoggingEvent Message

--- a/README.md
+++ b/README.md
@@ -1640,35 +1640,8 @@ You can change the timezone like this:
 ```
 
 The value of the `timeZone` element can be any string accepted by java's `TimeZone.getTimeZone(String id)` method.
-
-It can be a valid time zone ID. For instance, the time zone ID for the U.S. Pacific Time zone is "America/Los_Angeles".
-
-If the time zone you want is not represented by one of the supported IDs, then a custom time zone ID can be specified to produce a TimeZone. The syntax of a custom time zone ID is:
-
-```
-   CustomID:
-      GMT Sign Hours : Minutes
-      GMT Sign Hours Minutes
-      GMT Sign Hours
-      
-   Sign: one of
-      + -
-   
-   Hours:
-      Digit
-         Digit Digit
-         
-      Minutes:
-         Digit Digit
-
-      Digit: one of
-         0 1 2 3 4 5 6 7 8 9
-```
-
-_Hours_ must be between 0 to 23 and _Minutes_ must be between 00 to 59. 
-For example, "GMT+10" and "GMT+0010" mean ten hours and ten minutes ahead of GMT, respectively.
-
-Use a blank string or `null` to use the default TimeZone of the system.
+For example `America/Los_Angeles`, `GMT+10` or `UTC`.
+Use the special value `[DEFAULT]` to use the default TimeZone of the system.
 
 
 ## Customizing LoggingEvent Message

--- a/src/main/java/net/logstash/logback/composite/FormattedTimestampJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/FormattedTimestampJsonProvider.java
@@ -228,7 +228,7 @@ public abstract class FormattedTimestampJsonProvider<Event extends DeferredProce
      * produce a TimeZone. The syntax of a custom time zone ID is:
      *
      * <blockquote><pre>
-     * <a name="CustomID"><i>CustomID:</i></a>
+     * <i>CustomID:</i>
      *         <code>GMT</code> <i>Sign</i> <i>Hours</i> <code>:</code> <i>Minutes</i>
      *         <code>GMT</code> <i>Sign</i> <i>Hours</i> <i>Minutes</i>
      *         <code>GMT</code> <i>Sign</i> <i>Hours</i>

--- a/src/main/java/net/logstash/logback/composite/FormattedTimestampJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/FormattedTimestampJsonProvider.java
@@ -256,7 +256,7 @@ public abstract class FormattedTimestampJsonProvider<Event extends DeferredProce
         if (timeZoneId == null || timeZoneId.trim().isEmpty()) {
             this.timeZone = TimeZone.getDefault();
         } else {
-            this.timeZone = TimeZoneUtils.parse(timeZoneId);
+            this.timeZone = TimeZoneUtils.parseTimeZone(timeZoneId);
         }
         updateTimestampWriter();
     }

--- a/src/main/java/net/logstash/logback/composite/FormattedTimestampJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/FormattedTimestampJsonProvider.java
@@ -52,8 +52,16 @@ public abstract class FormattedTimestampJsonProvider<Event extends DeferredProce
      */
     public static final String UNIX_TIMESTAMP_AS_STRING = "[UNIX_TIMESTAMP_AS_STRING]";
 
+    /**
+     * The default {@link #pattern} value.
+     */
     private static final String DEFAULT_PATTERN = "[ISO_OFFSET_DATE_TIME]";
 
+    /**
+     * Keyword used by {@link #setTimeZone(String)} to denote the system default time zone.
+     */
+    public static final String DEFAULT_TIMEZONE_KEYWORD = "[DEFAULT]";
+    
     /**
      * The pattern in which to format the timestamp.
      *
@@ -219,44 +227,19 @@ public abstract class FormattedTimestampJsonProvider<Event extends DeferredProce
      * Set the timezone for which to write the timestamp.
      * Only applicable if the pattern is not {@value #UNIX_TIMESTAMP_AS_NUMBER} or {@value #UNIX_TIMESTAMP_AS_STRING}.
      * 
-     * <p>The TimeZone can be expressed into any format supported by {@link TimeZone#getTimeZone(String)}.
-     * It can be a valid time zone ID. For instance, the time zone ID for the
-     * U.S. Pacific Time zone is "America/Los_Angeles".
+     * <p>The value of the {@code timeZone} can be any string accepted by java's {@link TimeZone#getTimeZone(String)} method.
+     * For example "America/Los_Angeles" or "GMT+10".
      * 
-     * <p>If the time zone you want is not represented by one of the
-     * supported IDs, then a custom time zone ID can be specified to
-     * produce a TimeZone. The syntax of a custom time zone ID is:
-     *
-     * <blockquote><pre>
-     * <i>CustomID:</i>
-     *         <code>GMT</code> <i>Sign</i> <i>Hours</i> <code>:</code> <i>Minutes</i>
-     *         <code>GMT</code> <i>Sign</i> <i>Hours</i> <i>Minutes</i>
-     *         <code>GMT</code> <i>Sign</i> <i>Hours</i>
-     * <i>Sign:</i> one of
-     *         <code>+ -</code>
-     * <i>Hours:</i>
-     *         <i>Digit</i>
-     *         <i>Digit</i> <i>Digit</i>
-     * <i>Minutes:</i>
-     *         <i>Digit</i> <i>Digit</i>
-     * <i>Digit:</i> one of
-     *         <code>0 1 2 3 4 5 6 7 8 9</code>
-     * </pre></blockquote>
-     *
-     * <i>Hours</i> must be between 0 to 23 and <i>Minutes</i> must be
-     * between 00 to 59.  For example, "GMT+10" and "GMT+0010" mean ten
-     * hours and ten minutes ahead of GMT, respectively.
+     * <p>Use a blank string, {@code null} or the value {@value #DEFAULT_TIMEZONE_KEYWORD} to use the default TimeZone of the system.
      * 
-     * <p>Use a blank string or {@code null} to use the default TimeZone of the system.
-     * 
-     * @param timeZoneId the textual representation of the desired time zone
+     * @param timeZone the textual representation of the desired time zone
      * @throws IllegalArgumentException if the input string is not a valid TimeZone representation
      */
-    public void setTimeZone(String timeZoneId) {
-        if (timeZoneId == null || timeZoneId.trim().isEmpty()) {
+    public void setTimeZone(String timeZone) {
+        if (timeZone == null || timeZone.trim().isEmpty() || DEFAULT_TIMEZONE_KEYWORD.equalsIgnoreCase(timeZone)) {
             this.timeZone = TimeZone.getDefault();
         } else {
-            this.timeZone = TimeZoneUtils.parseTimeZone(timeZoneId);
+            this.timeZone = TimeZoneUtils.parseTimeZone(timeZone);
         }
         updateTimestampWriter();
     }

--- a/src/main/java/net/logstash/logback/util/TimeZoneUtils.java
+++ b/src/main/java/net/logstash/logback/util/TimeZoneUtils.java
@@ -61,7 +61,7 @@ public class TimeZoneUtils {
      * @throws IllegalArgumentException thrown when the string is not a valid TimeZone textual
      *                                  representation.
      */
-    public static TimeZone parse(String str) {
+    public static TimeZone parseTimeZone(String str) {
         TimeZone tz = TimeZone.getTimeZone(Objects.requireNonNull(str));
         
         /*

--- a/src/main/java/net/logstash/logback/util/TimeZoneUtils.java
+++ b/src/main/java/net/logstash/logback/util/TimeZoneUtils.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.logstash.logback.util;
+
+import java.util.Objects;
+import java.util.TimeZone;
+
+public class TimeZoneUtils {
+
+    private TimeZoneUtils() {
+        // utility class
+    }
+    
+    
+    /**
+     * Parse a string into the corresponding {@link TimeZone} using the format described by
+     * {@link TimeZone#getTimeZone(String)}.
+     * 
+     * <p>The string can be a valid time zone ID. For instance, the time zone ID for the
+     * U.S. Pacific Time zone is "America/Los_Angeles".
+     * 
+     * <p>If the time zone you want is not represented by one of the
+     * supported IDs, then a custom time zone ID can be specified to
+     * produce a TimeZone. The syntax of a custom time zone ID is:
+     *
+     * <blockquote><pre>
+     * <a name="CustomID"><i>CustomID:</i></a>
+     *         <code>GMT</code> <i>Sign</i> <i>Hours</i> <code>:</code> <i>Minutes</i>
+     *         <code>GMT</code> <i>Sign</i> <i>Hours</i> <i>Minutes</i>
+     *         <code>GMT</code> <i>Sign</i> <i>Hours</i>
+     * <i>Sign:</i> one of
+     *         <code>+ -</code>
+     * <i>Hours:</i>
+     *         <i>Digit</i>
+     *         <i>Digit</i> <i>Digit</i>
+     * <i>Minutes:</i>
+     *         <i>Digit</i> <i>Digit</i>
+     * <i>Digit:</i> one of
+     *         <code>0 1 2 3 4 5 6 7 8 9</code>
+     * </pre></blockquote>
+     *
+     * <i>Hours</i> must be between 0 to 23 and <i>Minutes</i> must be
+     * between 00 to 59.  For example, "GMT+10" and "GMT+0010" mean ten
+     * hours and ten minutes ahead of GMT, respectively.
+     * 
+     * @param str the string to parse into a valid {@link TimeZone}.
+     * @return the {@link TimeZone} corresponding to the input string
+     * @throws IllegalArgumentException thrown when the string is not a valid TimeZone textual
+     *                                  representation.
+     */
+    public static TimeZone parse(String str) {
+        TimeZone tz = TimeZone.getTimeZone(Objects.requireNonNull(str));
+        
+        /*
+         * Instead of throwing an exception when it fails to parse the string into a valid
+         * TimeZone, getTimeZone() returns a TimeZone with id "GMT".
+         * 
+         * If the returned TimeZone is GMT but the input string is not, then the input string
+         * was not a valid time zone representation.
+         */
+        if ("GMT".equals(tz.getID()) && !"GMT".equals(str)) {
+            throw new IllegalArgumentException("Invalid TimeZone value (was '" + str + "')");
+        }
+        
+        return tz;
+    }
+}

--- a/src/main/java/net/logstash/logback/util/TimeZoneUtils.java
+++ b/src/main/java/net/logstash/logback/util/TimeZoneUtils.java
@@ -37,7 +37,7 @@ public class TimeZoneUtils {
      * produce a TimeZone. The syntax of a custom time zone ID is:
      *
      * <blockquote><pre>
-     * <a name="CustomID"><i>CustomID:</i></a>
+     * <i>CustomID:</i>
      *         <code>GMT</code> <i>Sign</i> <i>Hours</i> <code>:</code> <i>Minutes</i>
      *         <code>GMT</code> <i>Sign</i> <i>Hours</i> <i>Minutes</i>
      *         <code>GMT</code> <i>Sign</i> <i>Hours</i>

--- a/src/main/java/net/logstash/logback/util/TimeZoneUtils.java
+++ b/src/main/java/net/logstash/logback/util/TimeZoneUtils.java
@@ -29,32 +29,8 @@ public class TimeZoneUtils {
      * Parse a string into the corresponding {@link TimeZone} using the format described by
      * {@link TimeZone#getTimeZone(String)}.
      * 
-     * <p>The string can be a valid time zone ID. For instance, the time zone ID for the
-     * U.S. Pacific Time zone is "America/Los_Angeles".
-     * 
-     * <p>If the time zone you want is not represented by one of the
-     * supported IDs, then a custom time zone ID can be specified to
-     * produce a TimeZone. The syntax of a custom time zone ID is:
-     *
-     * <blockquote><pre>
-     * <i>CustomID:</i>
-     *         <code>GMT</code> <i>Sign</i> <i>Hours</i> <code>:</code> <i>Minutes</i>
-     *         <code>GMT</code> <i>Sign</i> <i>Hours</i> <i>Minutes</i>
-     *         <code>GMT</code> <i>Sign</i> <i>Hours</i>
-     * <i>Sign:</i> one of
-     *         <code>+ -</code>
-     * <i>Hours:</i>
-     *         <i>Digit</i>
-     *         <i>Digit</i> <i>Digit</i>
-     * <i>Minutes:</i>
-     *         <i>Digit</i> <i>Digit</i>
-     * <i>Digit:</i> one of
-     *         <code>0 1 2 3 4 5 6 7 8 9</code>
-     * </pre></blockquote>
-     *
-     * <i>Hours</i> must be between 0 to 23 and <i>Minutes</i> must be
-     * between 00 to 59.  For example, "GMT+10" and "GMT+0010" mean ten
-     * hours and ten minutes ahead of GMT, respectively.
+     * <p>The value of the {@code timeZone} can be any string accepted by java's {@link TimeZone#getTimeZone(String)}
+     * method. For example "America/Los_Angeles" or "GMT+10".
      * 
      * @param str the string to parse into a valid {@link TimeZone}.
      * @return the {@link TimeZone} corresponding to the input string

--- a/src/test/java/net/logstash/logback/util/TimeZoneUtilsTest.java
+++ b/src/test/java/net/logstash/logback/util/TimeZoneUtilsTest.java
@@ -28,27 +28,27 @@ public class TimeZoneUtilsTest {
 
     @Test
     public void standardTimeZones() {
-        assertThat(TimeZoneUtils.parse("GMT").getID()).isEqualTo("GMT");
-        assertThat(TimeZoneUtils.parse("Europe/Brussels").getID()).isEqualTo("Europe/Brussels");
+        assertThat(TimeZoneUtils.parseTimeZone("GMT").getID()).isEqualTo("GMT");
+        assertThat(TimeZoneUtils.parseTimeZone("Europe/Brussels").getID()).isEqualTo("Europe/Brussels");
     }
     
     
     @Test
     public void customTimeZones() {
-        assertThat(TimeZoneUtils.parse("GMT+00").getID()).isEqualTo("GMT+00:00");
-        assertThat(TimeZoneUtils.parse("GMT+00:00").getID()).isEqualTo("GMT+00:00");
+        assertThat(TimeZoneUtils.parseTimeZone("GMT+00").getID()).isEqualTo("GMT+00:00");
+        assertThat(TimeZoneUtils.parseTimeZone("GMT+00:00").getID()).isEqualTo("GMT+00:00");
 
-        assertThat(TimeZoneUtils.parse("GMT-00").getID()).isEqualTo("GMT-00:00");
-        assertThat(TimeZoneUtils.parse("GMT-00:00").getID()).isEqualTo("GMT-00:00");
+        assertThat(TimeZoneUtils.parseTimeZone("GMT-00").getID()).isEqualTo("GMT-00:00");
+        assertThat(TimeZoneUtils.parseTimeZone("GMT-00:00").getID()).isEqualTo("GMT-00:00");
 
-        assertThat(TimeZoneUtils.parse("GMT+01:12").getID()).isEqualTo("GMT+01:12");
+        assertThat(TimeZoneUtils.parseTimeZone("GMT+01:12").getID()).isEqualTo("GMT+01:12");
     }
     
     
     @Test
     public void invalidTimeZone() {
-        assertThatThrownBy(() -> TimeZoneUtils.parse("foo")).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> TimeZoneUtils.parse("")).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> TimeZoneUtils.parse(null)).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> TimeZoneUtils.parseTimeZone("foo")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> TimeZoneUtils.parseTimeZone("")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> TimeZoneUtils.parseTimeZone(null)).isInstanceOf(NullPointerException.class);
     }
 }

--- a/src/test/java/net/logstash/logback/util/TimeZoneUtilsTest.java
+++ b/src/test/java/net/logstash/logback/util/TimeZoneUtilsTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.logstash.logback.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author brenuart
+ *
+ */
+public class TimeZoneUtilsTest {
+
+    @Test
+    public void standardTimeZones() {
+        assertThat(TimeZoneUtils.parse("GMT").getID()).isEqualTo("GMT");
+        assertThat(TimeZoneUtils.parse("Europe/Brussels").getID()).isEqualTo("Europe/Brussels");
+    }
+    
+    
+    @Test
+    public void customTimeZones() {
+        assertThat(TimeZoneUtils.parse("GMT+00").getID()).isEqualTo("GMT+00:00");
+        assertThat(TimeZoneUtils.parse("GMT+00:00").getID()).isEqualTo("GMT+00:00");
+
+        assertThat(TimeZoneUtils.parse("GMT-00").getID()).isEqualTo("GMT-00:00");
+        assertThat(TimeZoneUtils.parse("GMT-00:00").getID()).isEqualTo("GMT-00:00");
+
+        assertThat(TimeZoneUtils.parse("GMT+01:12").getID()).isEqualTo("GMT+01:12");
+    }
+    
+    
+    @Test
+    public void invalidTimeZone() {
+        assertThatThrownBy(() -> TimeZoneUtils.parse("foo")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> TimeZoneUtils.parse("")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> TimeZoneUtils.parse(null)).isInstanceOf(NullPointerException.class);
+    }
+}


### PR DESCRIPTION
Closes #650.