### PR TITLE
Allow FieldNames to override the field name of ContextJsonProvider when used in the context of IAccessEvent

### DIFF
--- a/src/main/java/net/logstash/logback/composite/ContextJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/ContextJsonProvider.java
@@ -18,7 +18,6 @@ package net.logstash.logback.composite;
 import java.io.IOException;
 
 import net.logstash.logback.fieldnames.LogstashCommonFieldNames;
-import net.logstash.logback.fieldnames.LogstashFieldNames;
 
 import ch.qos.logback.access.spi.IAccessEvent;
 import ch.qos.logback.classic.spi.ILoggingEvent;
@@ -53,9 +52,7 @@ public class ContextJsonProvider<Event extends DeferredProcessingAware> extends 
 
     @Override
     public void setFieldNames(LogstashCommonFieldNames fieldNames) {
-        if (fieldNames instanceof LogstashFieldNames) {
-            setFieldName(((LogstashFieldNames) fieldNames).getContext());
-        }
+        setFieldName(fieldNames.getContext());
     }
 
 }

--- a/src/main/java/net/logstash/logback/fieldnames/LogstashCommonFieldNames.java
+++ b/src/main/java/net/logstash/logback/fieldnames/LogstashCommonFieldNames.java
@@ -41,7 +41,8 @@ public abstract class LogstashCommonFieldNames {
     private String timestamp = FormattedTimestampJsonProvider.FIELD_TIMESTAMP;
     private String version = LogstashVersionJsonProvider.FIELD_VERSION;
     private String message = MessageJsonProvider.FIELD_MESSAGE;
-
+    private String context;
+    
     public String getTimestamp() {
         return timestamp;
     }
@@ -64,5 +65,24 @@ public abstract class LogstashCommonFieldNames {
 
     public void setMessage(String message) {
         this.message = message;
+    }
+    
+    /**
+     * The name of the context object field.
+     * <p>
+     * If this returns {@code null}, then the context fields will be written inline at the root level of the JSON event
+     * output (e.g. as a sibling to all the other fields in this class).
+     * <p>
+     * If this returns non-null, then the context fields will be written inside an object with field name returned by
+     * this method.
+     * 
+     * @return The name of the context object field.
+     */
+    public String getContext() {
+        return context;
+    }
+    
+    public void setContext(String context) {
+        this.context = context;
     }
 }

--- a/src/main/java/net/logstash/logback/fieldnames/LogstashFieldNames.java
+++ b/src/main/java/net/logstash/logback/fieldnames/LogstashFieldNames.java
@@ -45,7 +45,6 @@ public class LogstashFieldNames extends LogstashCommonFieldNames {
     private String rootStackTraceElementMethod = RootStackTraceElementJsonProvider.FIELD_METHOD_NAME;
     private String tags = TagsJsonProvider.FIELD_TAGS;
     private String mdc;
-    private String context;
     private String arguments;
     private String uuid = UuidProvider.FIELD_UUID;
 
@@ -161,22 +160,6 @@ public class LogstashFieldNames extends LogstashCommonFieldNames {
     
     public void setMdc(String mdc) {
         this.mdc = mdc;
-    }
-    
-    /**
-     * The name of the context object field.
-     * <p>
-     * If this returns null, then the context fields will be written inline at the root level of the JSON event output (e.g. as a sibling to all the other fields in this class).
-     * <p>
-     * If this returns non-null, then the context fields will be written inside an object with field name returned by this method
-     * @return The name of the context object field.
-     */
-    public String getContext() {
-        return context;
-    }
-    
-    public void setContext(String context) {
-        this.context = context;
     }
     
     /**


### PR DESCRIPTION
Closes #658