### PR TITLE
"reset()" ReusableByteBuffers when they are returned to the pool

### DIFF
--- a/src/main/java/net/logstash/logback/util/ReusableByteBufferPool.java
+++ b/src/main/java/net/logstash/logback/util/ReusableByteBufferPool.java
@@ -42,9 +42,10 @@ public class ReusableByteBufferPool extends ObjectPool<ReusableByteBuffer> {
      * 
      * @param buffer the buffer to return to the pool.
      */
-    protected void releaseInstance(ReusableByteBuffer buffer) {
+    @Override
+    protected boolean recycleInstance(ReusableByteBuffer buffer) {
         buffer.reset();
-        super.release(buffer);
+        return true;
     }
     
     

--- a/src/test/java/net/logstash/logback/util/ReusableByteBufferPoolTest.java
+++ b/src/test/java/net/logstash/logback/util/ReusableByteBufferPoolTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.logstash.logback.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author brenuart
+ *
+ */
+public class ReusableByteBufferPoolTest {
+
+    /*
+     * Assert ReusableByteBuffer are properly recycled when returned to the pool
+     */
+    @Test
+    public void testBufferRecycled() throws IOException {
+        ReusableByteBufferPool pool = ReusableByteBufferPool.create(1024);
+
+        // Acquire a buffer from the pool and write some content to it
+        ReusableByteBuffer buffer = pool.acquire();
+        buffer.write("hello".getBytes());
+        assertThat(buffer.size()).isNotZero();
+
+        // Release the buffer
+        pool.release(buffer);
+
+        // Ask again for a buffer - the previous should be returned and have a size()==0
+        ReusableByteBuffer secondBuffer = pool.acquire();
+        assertThat(secondBuffer).isSameAs(buffer);
+        assertThat(secondBuffer.size()).isZero();
+    }
+}


### PR DESCRIPTION
`ReusableByteBuffer`s must be properly reset when returned to the pool.