### PR TITLE
Run tests against Jackson 2.12 to ensure runtime compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,10 @@ jobs:
       - name: Build
         run: ./mvnw --batch-mode --no-transfer-progress --show-version --settings .github/maven/settings.xml verify
 
+      # Run tests against Jackson 2.12 to ensure runtime compatibility (do not recompile)
+      - name: Test Jackson 2.12
+        run: ./mvnw --batch-mode --no-transfer-progress --show-version --settings .github/maven/settings.xml -Djackson.version=2.12.5 surefire:test
+
       - name: Upload Test Reports
         uses: actions/upload-artifact@v2
         if: ${{ always() }}

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ then ensure the required dependencies (and appropriate versions) as specified in
 from the maven repository exist on the runtime classpath.
 Specifically, the following need to be available on the runtime classpath:
 
-* jackson-databind / jackson-core / jackson-annotations
+* jackson-databind / jackson-core / jackson-annotations >= 2.12.0
 * logback-core >= 1.2.0
 * logback-classic >= 1.2.0 (required for logging _LoggingEvents_)
 * logback-access >= 1.2.0 (required for logging _AccessEvents_)

--- a/pom.xml
+++ b/pom.xml
@@ -455,6 +455,13 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven-surefire-plugin.version}</version>
+                    <configuration>
+                        <!--
+                            GitHub CI runs tests against different jackson versions.
+                            Therefore, differentiate the report directories by jackson versions.
+                        -->
+                        <reportsDirectory>${project.build.directory}/surefire-reports/jackson-${jackson.version}</reportsDirectory>
+                    </configuration>
                 </plugin>
                 
                 <plugin>


### PR DESCRIPTION
Previously, I merged #668, which bumps jackson to 2.13.0.

In this PR, I have added an additional GitHub workflow step that will run tests against jackson 2.12.5 (without recompiling).  Running these tests ensures that even though logstash-logback-encoder is compiled against jackson 2.13.0, logstash-logback-encoder continues to work with jackson 2.12.5 at runtime.   If users need jackson 2.12.5, they can use dependencyManagement to pin jackson back to 2.12.5.

Note that logstash-logback-encoder is not compatible with jackson 2.11.x (the tests fail due to `java.lang.NoClassDefFoundError: com/fasterxml/jackson/core/filter/TokenFilter$Inclusion`)

I could not find a way to run the tests against both jackson 2.13.0 and 2.12.5 in a single maven command execution.  So, I had to add an additional maven execution.  Unfortunately, this means that during development, maven won't run the tests against 2.12 by default.  We can either execute them manually pre-commit.  Or push and wait for GitHub to tell us if they pass.  Any other ideas welcome.