### PR TITLE
Allow masking of multiple substrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1516,9 +1516,6 @@ for the path string format and more examples.  But in general:
 
 Specific values to be masked can be specified in several ways, as seen in the following example:
 
-When using regexes to identify strings to mask, all matches within each string field value will be replaced.
-If you want to match the full string field value, then use the beginning of line (`^`) and end of line (`$`) markers.
-
 ```xml
 <encoder class="net.logstash.logback.encoder.LogstashEncoder">
     <jsonGeneratorDecorator class="net.logstash.logback.mask.MaskingJsonGeneratorDecorator">
@@ -1560,6 +1557,13 @@ If you want to match the full string field value, then use the beginning of line
 
 Identifying data to mask by value is much more expensive than identifying data to mask by [path](#identifying-field-values-to-mask-by-path).
 Therefore, prefer identifying data to mask by path.
+
+The value to mask is passed through every value masker, with the output of one masker passed as input to the next masker. 
+This allows each masker to mask specific substrings within the value.
+The order in which the maskers are executed is not defined, and should not be relied upon.
+
+When using regexes to identify strings to mask, all matches within each string field value will be replaced.
+If you want to match the full string field value, then use the beginning of line (`^`) and end of line (`$`) markers.
 
 
 ## Customizing Standard Field Names

--- a/src/main/java/net/logstash/logback/mask/MaskingJsonGenerator.java
+++ b/src/main/java/net/logstash/logback/mask/MaskingJsonGenerator.java
@@ -525,17 +525,21 @@ public class MaskingJsonGenerator extends JsonGeneratorDelegate {
         return null;
     }
     /**
-     * @param value the value to potentially mask
+     * @param originalValue the value to potentially mask
      * @return the masked value for the current path and value if the value should be masked.
      *         otherwise returns null.
      */
-    private Object getMaskedValueForCurrentPathAndValue(Object value) {
+    private Object getMaskedValueForCurrentPathAndValue(Object originalValue) {
         JsonStreamContext context = getOutputContext();
+        Object localValue = originalValue;
         for (ValueMasker valueMasker : valueMaskers) {
-            Object maskedValue = valueMasker.mask(context, value);
+            Object maskedValue = valueMasker.mask(context, localValue);
             if (maskedValue != null) {
-                return maskedValue;
+                localValue = maskedValue;
             }
+        }
+        if (localValue != originalValue) {
+            return localValue;
         }
         return null;
     }

--- a/src/test/java/net/logstash/logback/mask/MaskingJsonGeneratorDecoratorTest.java
+++ b/src/test/java/net/logstash/logback/mask/MaskingJsonGeneratorDecoratorTest.java
@@ -120,6 +120,14 @@ public class MaskingJsonGeneratorDecoratorTest {
     }
 
     @Test
+    public void maskedSubstrings() throws IOException {
+        testMaskByValue(
+                "{\"fieldA\":\"tomask1\",\"fieldB\":\"tomask2\",\"fieldC\":\" tomask1-tomask2 \"}",
+                "{\"fieldA\":\"****\",\"fieldB\":\"****\",\"fieldC\":\" ****-**** \"}",
+                "tomask1", "tomask2");
+    }
+
+    @Test
     public void onlyMaskedField() throws IOException {
         testMaskByPath(
                 "{\"fieldA\":\"valueA\"}",


### PR DESCRIPTION
Previously, masking of a single value would stop after the first ValueMasker returned a masked value.
This meant that only one ValueMasker would process a string.
Now, all ValueMaskers are given the opportunity to process a value, which means that multiple substrings can be masked independently by different ValueMaskers

Fixes #690